### PR TITLE
Optimize libfiber with many features.

### DIFF
--- a/c/include/fiber/fiber_base.h
+++ b/c/include/fiber/fiber_base.h
@@ -50,7 +50,7 @@ FIBER_API ACL_FIBER* acl_fiber_create(void (*fn)(ACL_FIBER*, void*),
 	void* arg, size_t size);
 
 FIBER_API ACL_FIBER* acl_fiber_create2(const ACL_FIBER_ATTR *attr,
-	void (*fn)(ACL_FIBER*, void*), void* arg);
+	void (*fn)(ACL_FIBER*, void*), void *arg);
 
 typedef struct ACL_FIBER_FRAME {
 	char *func;
@@ -104,7 +104,7 @@ FIBER_API int acl_fiber_use_share_stack(const ACL_FIBER *fiber);
  * @param fiber {const ACL_FIBER*} the specified fiber object
  * @return {unsigned int} return the fiber ID
  */
-FIBER_API unsigned int acl_fiber_id(const ACL_FIBER* fiber);
+FIBER_API unsigned int acl_fiber_id(const ACL_FIBER *fiber);
 
 /**
  * Get the current running fiber's ID
@@ -118,62 +118,76 @@ FIBER_API unsigned int acl_fiber_self(void);
  *  fiber will be used
  * @param errnum {int} the error number
  */
-FIBER_API void acl_fiber_set_errno(ACL_FIBER* fiber, int errnum);
+FIBER_API void acl_fiber_set_errno(ACL_FIBER *fiber, int errnum);
 
 /**
  * Get the error number of assosiated fiber
  * @param fiber {ACL_FIBER*} the specified fiber, if NULL the current running
  * @return {int} get the error number of assosiated fiber
  */
-FIBER_API int acl_fiber_errno(ACL_FIBER* fiber);
+FIBER_API int acl_fiber_errno(ACL_FIBER *fiber);
 
 /**
  * @deprecated
  * @param fiber {ACL_FIBER*}
  * @param yesno {int}
  */
-FIBER_API void acl_fiber_keep_errno(ACL_FIBER* fiber, int yesno);
+FIBER_API void acl_fiber_keep_errno(ACL_FIBER *fiber, int yesno);
 
 /**
  * Get the assosiated fiber's status
- * @param fiber {ACL_FIBER*} the specified fiber, if NULL the current running
- * @return {int}
+ * @param fiber {ACL_FIBER*} The specified fiber, if fiber is NULL the current
+ *  running fiber will be used.
+ * @return {int} Return ths status defined as FIBER_STATUS_XXX.
  */
-FIBER_API int acl_fiber_status(const ACL_FIBER* fiber);
+FIBER_API int acl_fiber_status(const ACL_FIBER *fiber);
 
 /**
- * Kill the suspended fiber and notify it to exit
+ * Get the specified fiber's waiting status, defined as FIBER_WAIT_XXX.
+ * @param fiber {ACL_FIBER*} The specified fiber or the running fiber if the
+ *  fiber is NULL.
+ */
+FIBER_API int acl_fiber_waiting_status(const ACL_FIBER *fiber);
+
+/**
+ * Kill the suspended fiber and notify it to exit in asynchronous mode
  * @param fiber {const ACL_FIBER*} the specified fiber, NOT NULL
  */
-FIBER_API void acl_fiber_kill(ACL_FIBER* fiber);
+FIBER_API void acl_fiber_kill(ACL_FIBER *fiber);
+
+/**
+ * Kill the suspended fiber and notify it to exit in synchronous mode
+ * @param fiber {const ACL_FIBER*} the specified fiber, NOT NULL
+ */
+FIBER_API void acl_fiber_kill_wait(ACL_FIBER *fiber);
 
 /**
  * Check if the specified fiber has been killed
  * @param fiber {ACL_FIBER*} the specified fiber, if NULL the current running
  * @return {int} non zero returned if been killed
  */
-FIBER_API int acl_fiber_killed(ACL_FIBER* fiber);
+FIBER_API int acl_fiber_killed(ACL_FIBER *fiber);
 
 /**
  * Check if the specified fiber has been signaled
  * @param fiber {ACL_FIBER*} the specified fiber, if NULL the current running
  * @return {int} non zero returned if been signed
  */
-FIBER_API int acl_fiber_signaled(ACL_FIBER* fiber);
+FIBER_API int acl_fiber_signaled(ACL_FIBER *fiber);
 
 /**
  * Check if the specified fiber's socket has been closed by another fiber
  * @param fiber {ACL_FIBER*} the specified fiber, if NULL the current running
  * @return {int} non zero returned if been closed
  */
-FIBER_API int acl_fiber_closed(ACL_FIBER* fiber);
+FIBER_API int acl_fiber_closed(ACL_FIBER *fiber);
 
 /**
  * Check if the specified fiber has been canceled
  * @param fiber {ACL_FIBER*} the specified fiber, if NULL the current running
  * @return {int} non zero returned if been canceled
  */
-FIBER_API int acl_fiber_canceled(ACL_FIBER* fiber);
+FIBER_API int acl_fiber_canceled(ACL_FIBER *fiber);
 
 /**
  * Clear the fiber's flag and errnum to 0.
@@ -182,18 +196,25 @@ FIBER_API int acl_fiber_canceled(ACL_FIBER* fiber);
 FIBER_API void acl_fiber_clear(ACL_FIBER *fiber);
 
 /**
- * Wakeup the suspended fiber with the assosiated signal number
+ * Wakeup the suspended fiber with the assosiated signal number asynchronously
  * @param fiber {const ACL_FIBER*} the specified fiber, NOT NULL
  * @param signum {int} SIGINT, SIGKILL, SIGTERM ... refer to bits/signum.h
  */
-FIBER_API void acl_fiber_signal(ACL_FIBER* fiber, int signum);
+FIBER_API void acl_fiber_signal(ACL_FIBER *fiber, int signum);
+
+/**
+ * Wakeup the suspended fiber with the assosiated signal number synchronously
+ * @param fiber {const ACL_FIBER*} the specified fiber, NOT NULL
+ * @param signum {int} SIGINT, SIGKILL, SIGTERM ... refer to bits/signum.h
+ */
+FIBER_API void acl_fiber_signal_wait(ACL_FIBER *fiber, int signum);
 
 /**
  * Get the signal number got from other fiber
  * @param fiber {ACL_FIBER*} the specified fiber, if NULL the current running
  * @retur {int} the signal number got
  */
-FIBER_API int acl_fiber_signum(ACL_FIBER* fiber);
+FIBER_API int acl_fiber_signum(ACL_FIBER *fiber);
 
 /**
  * Suspend the current running fiber
@@ -205,7 +226,7 @@ FIBER_API int acl_fiber_yield(void);
  * Add the suspended fiber into resuming queue
  * @param fiber {ACL_FIBER*} the fiber, NOT NULL
  */
-FIBER_API void acl_fiber_ready(ACL_FIBER* fiber);
+FIBER_API void acl_fiber_ready(ACL_FIBER *fiber);
 
 /**
  * Suspend the current fiber and switch to run the next ready fiber
@@ -261,43 +282,43 @@ FIBER_API void acl_fiber_schedule_stop(void);
 
 /**
  * Let the current fiber sleep for a while
- * @param milliseconds {unsigned int} the milliseconds to sleep
+ * @param milliseconds {size_t} the milliseconds to sleep
  * @return {unsigned int} the rest milliseconds returned after wakeup
  */
-FIBER_API unsigned int acl_fiber_delay(unsigned int milliseconds);
+FIBER_API size_t acl_fiber_delay(size_t milliseconds);
 
 /**
  * Let the current fiber sleep for a while
- * @param seconds {unsigned int} the seconds to sleep
- * @return {unsigned int} the rest seconds returned after wakeup
+ * @param seconds {size_t} the seconds to sleep
+ * @return {size_t} the rest seconds returned after wakeup
  */
-FIBER_API unsigned int acl_fiber_sleep(unsigned int seconds);
+FIBER_API size_t acl_fiber_sleep(size_t seconds);
 
 /**
  * Create one fiber timer
- * @param milliseconds {unsigned int} the timer wakeup milliseconds
+ * @param milliseconds {size_t} the timer wakeup milliseconds
  * @param size {size_t} the virtual memory of the created fiber
  * @param fn {void (*)(ACL_FIBER*, void*)} the callback when fiber wakeup
  * @param ctx {void*} the second parameter of the callback fn
  * @return {ACL_FIBER*} the new created fiber returned
  */
-FIBER_API ACL_FIBER* acl_fiber_create_timer(unsigned int milliseconds,
-	size_t size, void (*fn)(ACL_FIBER*, void*), void* ctx);
+FIBER_API ACL_FIBER* acl_fiber_create_timer(size_t milliseconds,
+	size_t size, void (*fn)(ACL_FIBER*, void*), void *ctx);
 
 /**
  * Reset the timer milliseconds time before the timer fiber wakeup
  * @param timer {ACL_FIBER*} the fiber created by acl_fiber_create_timer
- * @param milliseconds {unsigned int} the new timer wakeup milliseconds
+ * @param milliseconds {size_t} the new timer wakeup milliseconds
  * @return {int} return 0 if rest timer success, else return -1 if failed
  */
-FIBER_API int acl_fiber_reset_timer(ACL_FIBER* timer, unsigned int milliseconds);
+FIBER_API int acl_fiber_reset_timer(ACL_FIBER *timer, size_t milliseconds);
 
 /**
  * Set the DNS service addr
  * @param ip {const char*} ip of the DNS service
  * @param port {int} port of the DNS service
  */
-FIBER_API void acl_fiber_set_dns(const char* ip, int port);
+FIBER_API void acl_fiber_set_dns(const char *ip, int port);
 
 /* For fiber specific */
 
@@ -312,7 +333,7 @@ FIBER_API void acl_fiber_set_dns(const char* ip, int port);
  * @return {int} the integer value(>0) of indexed key returned, value less than
  *  0 will be returned if no running fiber
  */
-FIBER_API int acl_fiber_set_specific(int* key, void* ctx, void (*free_fn)(void*));
+FIBER_API int acl_fiber_set_specific(int *key, void *ctx, void (*free_fn)(void*));
 
 /**
  * Get the current fiber's local object assosiated with the specified indexed key

--- a/c/include/fiber/fiber_define.h
+++ b/c/include/fiber/fiber_define.h
@@ -8,6 +8,33 @@ extern "C" {
 
 typedef intptr_t acl_handle_t;
 
+/**
+ * The specified fiber's current status type.
+ */
+enum {
+	FIBER_STATUS_NONE	= (0),
+	FIBER_STATUS_READY	= (1 << 0),
+	FIBER_STATUS_RUNNING	= (1 << 1),
+	FIBER_STATUS_SUSPEND	= (1 << 2),
+	FIBER_STATUS_EXITING	= (1 << 3),
+};
+
+/**
+ * The suspended (in FIBER_STATUS_SUSPEND status) fiber's waiting type.
+ */
+enum {
+	FIBER_WAIT_NONE		= (0),
+	FIBER_WAIT_READ		= (1 << 1),
+	FIBER_WAIT_WRITE	= (1 << 2),
+	FIBER_WAIT_POLL		= (1 << 3),
+	FIBER_WAIT_EPOLL	= (1 << 4),
+	FIBER_WAIT_MUTEX	= (1 << 5),
+	FIBER_WAIT_COND		= (1 << 6),
+	FIBER_WAIT_LOCK		= (1 << 7),
+	FIBER_WAIT_SEM		= (1 << 8),
+	FIBER_WAIT_DELAY	= (1 << 9),
+};
+
 #if defined(_WIN32) || defined (_WIN64)
 # include <winsock2.h>
 
@@ -44,6 +71,7 @@ typedef int socklen_t;
 # define	FIBER_ENOBUFS		WSAENOBUFS
 # define	FIBER_ECONNABORTED	WSAECONNABORTED
 # define	FIBER_EINPROGRESS	WSAEINPROGRESS
+# define	FIBER_ECANCELED		ECANCELED
 
 #else
 
@@ -82,6 +110,7 @@ typedef int socket_t;
 # define	FIBER_ENOBUFS		ENOBUFS
 # define	FIBER_ECONNABORTED	ECONNABORTED
 # define	FIBER_EINPROGRESS	EINPROGRESS
+# define	FIBER_ECANCELED		ECANCELED
 
 # include <sys/syscall.h>
 # if defined(SYS_recvmmsg) && defined(SYS_sendmmsg) && !defined(ANDROID)

--- a/c/src/common/avl.c
+++ b/c/src/common/avl.c
@@ -45,19 +45,19 @@
  *
  *	- The AVL specific data structures are physically embedded as fields
  *	  in the "using" data structures.  To maintain generality the code
- *	  must constantly translate between "avl_node_t *" and containing
+ *	  must constantly translate between "fiber_avl_node_t *" and containing
  *	  data structure "void *"s by adding/subracting the avl_offset.
  *
  *	- Since the AVL data is always embedded in other structures, there is
  *	  no locking or memory allocation in the AVL routines. This must be
  *	  provided for by the enclosing data structure's semantics. Typically,
- *	  avl_insert()/_add()/_remove()/avl_insert_here() require some kind of
+ *	  fiber_avl_insert()/_add()/_remove()/fiber_avl_insert_here() require some kind of
  *	  exclusive write lock. Other operations require a read lock.
  *
  *      - The implementation uses iteration instead of explicit recursion,
  *	  since it is intended to run on limited size kernel stacks. Since
  *	  there is no recursion stack present to move "up" in the tree,
- *	  there is an explicit "parent" link in the avl_node_t.
+ *	  there is an explicit "parent" link in the fiber_avl_node_t.
  *
  *      - The left/right children pointers of a node are in an array.
  *	  In the code, variables (instead of constants) are used to represent
@@ -81,11 +81,11 @@
  *	  allows using half as much code (and hence cache footprint) for tree
  *	  manipulations and eliminates many conditional branches.
  *
- *	- The avl_index_t is an opaque "cookie" used to find nodes at or
+ *	- The fiber_avl_index_t is an opaque "cookie" used to find nodes at or
  *	  adjacent to where a new value would be inserted in the tree. The value
- *	  is a modified "avl_node_t *".  The bottom bit (normally 0 for a
+ *	  is a modified "fiber_avl_node_t *".  The bottom bit (normally 0 for a
  *	  pointer) is set to indicate if that the new node has a value greater
- *	  than the value of the indicated "avl_node_t *".
+ *	  than the value of the indicated "fiber_avl_node_t *".
  */
 
 #include "stdafx.h"
@@ -123,10 +123,10 @@ static const int  avl_balance2child[]	= {0, 0, 1};
  * otherwise next node
  */
 void *
-avl_walk(avl_tree_t *tree, void	*oldnode, int left)
+fiber_avl_walk(fiber_avl_tree_t *tree, void	*oldnode, int left)
 {
 	size_t off = tree->avl_offset;
-	avl_node_t *node = AVL_DATA2NODE(oldnode, off);
+	fiber_avl_node_t *node = AVL_DATA2NODE(oldnode, off);
 	int right = 1 - left;
 	int was_child;
 
@@ -170,10 +170,10 @@ avl_walk(avl_tree_t *tree, void	*oldnode, int left)
  * (leftmost child from root of tree)
  */
 void *
-avl_first(avl_tree_t *tree)
+fiber_avl_first(fiber_avl_tree_t *tree)
 {
-	avl_node_t *node;
-	avl_node_t *prev = NULL;
+	fiber_avl_node_t *node;
+	fiber_avl_node_t *prev = NULL;
 	size_t off = tree->avl_offset;
 
 	for (node = tree->avl_root; node != NULL; node = node->avl_child[0])
@@ -189,10 +189,10 @@ avl_first(avl_tree_t *tree)
  * (rightmost child from root of tree)
  */
 void *
-avl_last(avl_tree_t *tree)
+fiber_avl_last(fiber_avl_tree_t *tree)
 {
-	avl_node_t *node;
-	avl_node_t *prev = NULL;
+	fiber_avl_node_t *node;
+	fiber_avl_node_t *prev = NULL;
 	size_t off = tree->avl_offset;
 
 	for (node = tree->avl_root; node != NULL; node = node->avl_child[1])
@@ -206,17 +206,17 @@ avl_last(avl_tree_t *tree)
 /*
  * Access the node immediately before or after an insertion point.
  *
- * "avl_index_t" is a (avl_node_t *) with the bottom bit indicating a child
+ * "fiber_avl_index_t" is a (fiber_avl_node_t *) with the bottom bit indicating a child
  *
  * Return value:
  *	NULL: no node in the given direction
  *	"void *"  of the found tree node
  */
 void *
-avl_nearest(avl_tree_t *tree, avl_index_t where, int direction)
+fiber_avl_nearest(fiber_avl_tree_t *tree, fiber_avl_index_t where, int direction)
 {
 	int child = AVL_INDEX2CHILD(where);
-	avl_node_t *node = AVL_INDEX2NODE(where);
+	fiber_avl_node_t *node = AVL_INDEX2NODE(where);
 	void *data;
 	size_t off = tree->avl_offset;
 
@@ -228,7 +228,7 @@ avl_nearest(avl_tree_t *tree, avl_index_t where, int direction)
 	if (child != direction)
 		return (data);
 
-	return (avl_walk(tree, data, direction));
+	return (fiber_avl_walk(tree, data, direction));
 }
 
 
@@ -242,10 +242,10 @@ avl_nearest(avl_tree_t *tree, avl_index_t where, int direction)
  *	"void *"  of the found tree node
  */
 void *
-avl_find(avl_tree_t *tree, void *value, avl_index_t *where)
+fiber_avl_find(fiber_avl_tree_t *tree, void *value, fiber_avl_index_t *where)
 {
-	avl_node_t *node;
-	avl_node_t *prev = NULL;
+	fiber_avl_node_t *node;
+	fiber_avl_node_t *prev = NULL;
 	int child = 0;
 	int diff;
 	size_t off = tree->avl_offset;
@@ -290,18 +290,18 @@ avl_find(avl_tree_t *tree, void *value, avl_index_t *where)
  * -2 or +2.
  */
 static int
-avl_rotation(avl_tree_t *tree, avl_node_t *node, int balance)
+avl_rotation(fiber_avl_tree_t *tree, fiber_avl_node_t *node, int balance)
 {
 	int left = !(balance < 0);	/* when balance = -2, left will be 0 */
 	int right = 1 - left;
 	int left_heavy = balance >> 1;
 	int right_heavy = -left_heavy;
-	avl_node_t *parent = AVL_XPARENT(node);
-	avl_node_t *child = node->avl_child[left];
-	avl_node_t *cright;
-	avl_node_t *gchild;
-	avl_node_t *gright;
-	avl_node_t *gleft;
+	fiber_avl_node_t *parent = AVL_XPARENT(node);
+	fiber_avl_node_t *child = node->avl_child[left];
+	fiber_avl_node_t *cright;
+	fiber_avl_node_t *gchild;
+	fiber_avl_node_t *gright;
+	fiber_avl_node_t *gleft;
 	int which_child = AVL_XCHILD(node);
 	int child_bal = AVL_XBALANCE(child);
 
@@ -459,20 +459,20 @@ avl_rotation(avl_tree_t *tree, avl_node_t *node, int balance)
 
 
 /*
- * Insert a new node into an AVL tree at the specified (from avl_find()) place.
+ * Insert a new node into an AVL tree at the specified (from fiber_avl_find()) place.
  *
- * Newly inserted nodes are always leaf nodes in the tree, since avl_find()
- * searches out to the leaf positions.  The avl_index_t indicates the node
+ * Newly inserted nodes are always leaf nodes in the tree, since fiber_avl_find()
+ * searches out to the leaf positions.  The fiber_avl_index_t indicates the node
  * which will be the parent of the new node.
  *
  * After the node is inserted, a single rotation further up the tree may
  * be necessary to maintain an acceptable AVL balance.
  */
 void
-avl_insert(avl_tree_t *tree, void *new_data, avl_index_t where)
+fiber_avl_insert(fiber_avl_tree_t *tree, void *new_data, fiber_avl_index_t where)
 {
-	avl_node_t *node;
-	avl_node_t *parent = AVL_INDEX2NODE(where);
+	fiber_avl_node_t *node;
+	fiber_avl_node_t *parent = AVL_INDEX2NODE(where);
 	int old_balance;
 	int new_balance;
 	int which_child = AVL_INDEX2CHILD(where);
@@ -559,13 +559,13 @@ avl_insert(avl_tree_t *tree, void *new_data, avl_index_t where)
  * is correctly ordered at every step of the way in DEBUG kernels.
  */
 void
-avl_insert_here(
-	avl_tree_t *tree,
+fiber_avl_insert_here(
+	fiber_avl_tree_t *tree,
 	void *new_data,
 	void *here,
 	int direction)
 {
-	avl_node_t *node;
+	fiber_avl_node_t *node;
 	int child = direction;	/* rely on AVL_BEFORE == 0, AVL_AFTER == 1 */
 #ifdef DEBUG
 	int diff;
@@ -612,16 +612,16 @@ avl_insert_here(
 	}
 	ASSERT(node->avl_child[child] == NULL);
 
-	avl_insert(tree, new_data, AVL_MKINDEX(node, child));
+	fiber_avl_insert(tree, new_data, AVL_MKINDEX(node, child));
 }
 
 /*
  * Add a new node to an AVL tree.
  */
 void
-avl_add(avl_tree_t *tree, void *new_node)
+fiber_avl_add(fiber_avl_tree_t *tree, void *new_node)
 {
-	avl_index_t where = 0;
+	fiber_avl_index_t where = 0;
 
 	/*
 	 * This is unfortunate.  We want to call panic() here, even for
@@ -629,13 +629,13 @@ avl_add(avl_tree_t *tree, void *new_node)
 	 * in libc or else the rtld build process gets confused.  So, all we can
 	 * do in userland is resort to a normal ASSERT().
 	 */
-	if (avl_find(tree, new_node, &where) != NULL)
+	if (fiber_avl_find(tree, new_node, &where) != NULL)
 #ifdef _KERNEL
-		panic("avl_find() succeeded inside avl_add()");
+		panic("fiber_avl_find() succeeded inside fiber_avl_add()");
 #else
 		ASSERT(0);
 #endif
-	avl_insert(tree, new_node, where);
+	fiber_avl_insert(tree, new_node, where);
 }
 
 /*
@@ -662,12 +662,12 @@ avl_add(avl_tree_t *tree, void *new_node)
  * height due to a rotation.
  */
 void
-avl_remove(avl_tree_t *tree, void *data)
+fiber_avl_remove(fiber_avl_tree_t *tree, void *data)
 {
-	avl_node_t *delete;
-	avl_node_t *parent;
-	avl_node_t *node;
-	avl_node_t tmp;
+	fiber_avl_node_t *delete;
+	fiber_avl_node_t *parent;
+	fiber_avl_node_t *node;
+	fiber_avl_node_t tmp;
 	int old_balance;
 	int new_balance;
 	int left;
@@ -808,11 +808,11 @@ avl_remove(avl_tree_t *tree, void *data)
 }
 
 #define	AVL_REINSERT(tree, obj)		\
-	avl_remove((tree), (obj));	\
-	avl_add((tree), (obj))
+	fiber_avl_remove((tree), (obj));	\
+	fiber_avl_add((tree), (obj))
 
 boolean_t
-avl_update_lt(avl_tree_t *t, void *obj)
+fiber_avl_update_lt(fiber_avl_tree_t *t, void *obj)
 {
 	void *neighbor;
 
@@ -829,7 +829,7 @@ avl_update_lt(avl_tree_t *t, void *obj)
 }
 
 boolean_t
-avl_update_gt(avl_tree_t *t, void *obj)
+fiber_avl_update_gt(fiber_avl_tree_t *t, void *obj)
 {
 	void *neighbor;
 
@@ -846,7 +846,7 @@ avl_update_gt(avl_tree_t *t, void *obj)
 }
 
 boolean_t
-avl_update(avl_tree_t *t, void *obj)
+fiber_avl_update(fiber_avl_tree_t *t, void *obj)
 {
 	void *neighbor;
 
@@ -869,13 +869,13 @@ avl_update(avl_tree_t *t, void *obj)
  * initialize a new AVL tree
  */
 void
-avl_create(avl_tree_t *tree, int (*compar) (const void *, const void *),
+fiber_avl_create(fiber_avl_tree_t *tree, int (*compar) (const void *, const void *),
     size_t size, size_t offset)
 {
 	ASSERT(tree);
 	ASSERT(compar);
 	ASSERT(size > 0);
-	ASSERT(size >= offset + sizeof (avl_node_t));
+	ASSERT(size >= offset + sizeof (fiber_avl_node_t));
 #ifdef _LP64
 	ASSERT((offset & 0x7) == 0);
 #endif
@@ -892,7 +892,7 @@ avl_create(avl_tree_t *tree, int (*compar) (const void *, const void *),
  */
 /* ARGSUSED */
 void
-avl_destroy(avl_tree_t *tree fiber_unused)
+fiber_avl_destroy(fiber_avl_tree_t *tree fiber_unused)
 {
 	ASSERT(tree);
 	ASSERT(tree->avl_numnodes == 0);
@@ -904,14 +904,14 @@ avl_destroy(avl_tree_t *tree fiber_unused)
  * Return the number of nodes in an AVL tree.
  */
 ulong_t
-avl_numnodes(avl_tree_t *tree)
+fiber_avl_numnodes(fiber_avl_tree_t *tree)
 {
 	ASSERT(tree);
 	return (tree->avl_numnodes);
 }
 
 boolean_t
-avl_is_empty(avl_tree_t *tree)
+fiber_avl_is_empty(fiber_avl_tree_t *tree)
 {
 	ASSERT(tree);
 	return (tree->avl_numnodes == 0);
@@ -929,20 +929,20 @@ avl_is_empty(avl_tree_t *tree)
  *	void *cookie = NULL;
  *	my_data_t *node;
  *
- *	while ((node = avl_destroy_nodes(tree, &cookie)) != NULL)
+ *	while ((node = fiber_avl_destroy_nodes(tree, &cookie)) != NULL)
  *		free(node);
- *	avl_destroy(tree);
+ *	fiber_avl_destroy(tree);
  *
- * The cookie is really an avl_node_t to the current node's parent and
+ * The cookie is really an fiber_avl_node_t to the current node's parent and
  * an indication of which child you looked at last.
  *
  * On input, a cookie value of CHILDBIT indicates the tree is done.
  */
 void *
-avl_destroy_nodes(avl_tree_t *tree, void **cookie)
+fiber_avl_destroy_nodes(fiber_avl_tree_t *tree, void **cookie)
 {
-	avl_node_t	*node;
-	avl_node_t	*parent;
+	fiber_avl_node_t	*node;
+	fiber_avl_node_t	*parent;
 	int		child;
 	void		*first;
 	size_t		off = tree->avl_offset;
@@ -951,7 +951,7 @@ avl_destroy_nodes(avl_tree_t *tree, void **cookie)
 	 * Initial calls go to the first node or it's right descendant.
 	 */
 	if (*cookie == NULL) {
-		first = avl_first(tree);
+		first = fiber_avl_first(tree);
 
 		/*
 		 * deal with an empty tree
@@ -969,7 +969,7 @@ avl_destroy_nodes(avl_tree_t *tree, void **cookie)
 	/*
 	 * If there is no parent to return to we are done.
 	 */
-	parent = (avl_node_t *)((uintptr_t)(*cookie) & ~CHILDBIT);
+	parent = (fiber_avl_node_t *)((uintptr_t)(*cookie) & ~CHILDBIT);
 	if (parent == NULL) {
 		if (tree->avl_root != NULL) {
 			ASSERT(tree->avl_numnodes == 1);

--- a/c/src/common/avl.h
+++ b/c/src/common/avl.h
@@ -63,39 +63,39 @@ extern "C" {
  *	or prev node	 constant	between constant and O(log(n))
  *
  *
- * The data structure nodes are anchored at an "avl_tree_t" (the equivalent
+ * The data structure nodes are anchored at an "fiber_avl_tree_t" (the equivalent
  * of a list header) and the individual nodes will have a field of
- * type "avl_node_t" (corresponding to list pointers).
+ * type "fiber_avl_node_t" (corresponding to list pointers).
  *
- * The type "avl_index_t" is used to indicate a position in the list for
+ * The type "fiber_avl_index_t" is used to indicate a position in the list for
  * certain calls.
  *
  * The usage scenario is generally:
  *
- * 1. Create the list/tree with: avl_create()
+ * 1. Create the list/tree with: fiber_avl_create()
  *
  * followed by any mixture of:
  *
- * 2a. Insert nodes with: avl_add(), or avl_find() and avl_insert()
+ * 2a. Insert nodes with: fiber_avl_add(), or fiber_avl_find() and fiber_avl_insert()
  *
  * 2b. Visited elements with:
- *	 avl_first() - returns the lowest valued node
- *	 avl_last() - returns the highest valued node
+ *	 fiber_avl_first() - returns the lowest valued node
+ *	 fiber_avl_last() - returns the highest valued node
  *	 AVL_NEXT() - given a node go to next higher one
  *	 AVL_PREV() - given a node go to previous lower one
  *
  * 2c.  Find the node with the closest value either less than or greater
- *	than a given value with avl_nearest().
+ *	than a given value with fiber_avl_nearest().
  *
- * 2d. Remove individual nodes from the list/tree with avl_remove().
+ * 2d. Remove individual nodes from the list/tree with fiber_avl_remove().
  *
  * and finally when the list is being destroyed
  *
- * 3. Use avl_destroy_nodes() to quickly process/free up any remaining nodes.
- *    Note that once you use avl_destroy_nodes(), you can no longer
- *    use any routine except avl_destroy_nodes() and avl_destoy().
+ * 3. Use fiber_avl_destroy_nodes() to quickly process/free up any remaining nodes.
+ *    Note that once you use fiber_avl_destroy_nodes(), you can no longer
+ *    use any routine except fiber_avl_destroy_nodes() and avl_destoy().
  *
- * 4. Use avl_destroy() to destroy the AVL tree itself.
+ * 4. Use fiber_avl_destroy() to destroy the AVL tree itself.
  *
  * Any locking for multiple thread access is up to the user to provide, just
  * as is needed for any linked list implementation.
@@ -104,12 +104,12 @@ extern "C" {
 /*
  * Type used for the root of the AVL tree.
  */
-typedef struct avl_tree avl_tree_t;
+typedef struct fiber_avl_tree fiber_avl_tree_t;
 
 /*
  * The data nodes in the AVL tree must have a field of this type.
  */
-typedef struct avl_node avl_node_t;
+typedef struct fiber_avl_node fiber_avl_node_t;
 
 /*
  * An opaque type used to locate a position in the tree where a node
@@ -117,16 +117,16 @@ typedef struct avl_node avl_node_t;
  */
 #ifdef	MS_VC6
 typedef unsigned int uintptr_t;
-typedef uintptr_t avl_index_t;
+typedef uintptr_t fiber_avl_index_t;
 #elif	defined(BORLAND_CB)
 typedef unsigned int uintptr_t;
-typedef uintptr_t avl_index_t;
+typedef uintptr_t fiber_avl_index_t;
 #else
-typedef uintptr_t avl_index_t;
+typedef uintptr_t fiber_avl_index_t;
 #endif
 
 /*
- * Direction constants used for avl_nearest().
+ * Direction constants used for fiber_avl_nearest().
  */
 #define	AVL_BEFORE	(0)
 #define	AVL_AFTER	(1)
@@ -136,12 +136,12 @@ typedef uintptr_t avl_index_t;
  * Prototypes
  *
  * Where not otherwise mentioned, "void *" arguments are a pointer to the
- * user data structure which must contain a field of type avl_node_t.
+ * user data structure which must contain a field of type fiber_avl_node_t.
  *
  * Also assume the user data structures looks like:
  *	stuct my_type {
  *		...
- *		avl_node_t	my_link;
+ *		fiber_avl_node_t	my_link;
  *		...
  *	};
  */
@@ -155,40 +155,40 @@ typedef uintptr_t avl_index_t;
  * size   - the value of sizeof(struct my_type)
  * offset - the value of OFFSETOF(struct my_type, my_link)
  */
-void avl_create(avl_tree_t *tree,
+void fiber_avl_create(fiber_avl_tree_t *tree,
 	int (*compar) (const void *, const void *), size_t size, size_t offset);
 
 
 /*
  * Find a node with a matching value in the tree. Returns the matching node
  * found. If not found, it returns NULL and then if "where" is not NULL it sets
- * "where" for use with avl_insert() or avl_nearest().
+ * "where" for use with fiber_avl_insert() or fiber_avl_nearest().
  *
  * node   - node that has the value being looked for
- * where  - position for use with avl_nearest() or avl_insert(), may be NULL
+ * where  - position for use with fiber_avl_nearest() or fiber_avl_insert(), may be NULL
  */
-void *avl_find(avl_tree_t *tree, void *node, avl_index_t *where);
+void *fiber_avl_find(fiber_avl_tree_t *tree, void *node, fiber_avl_index_t *where);
 
 /*
  * Insert a node into the tree.
  *
  * node   - the node to insert
- * where  - position as returned from avl_find()
+ * where  - position as returned from fiber_avl_find()
  */
-void avl_insert(avl_tree_t *tree, void *node, avl_index_t where);
+void fiber_avl_insert(fiber_avl_tree_t *tree, void *node, fiber_avl_index_t where);
 
 /*
  * Insert "new_data" in "tree" in the given "direction" either after
  * or before the data "here".
  *
  * This might be usefull for avl clients caching recently accessed
- * data to avoid doing avl_find() again for insertion.
+ * data to avoid doing fiber_avl_find() again for insertion.
  *
  * new_data	- new data to insert
  * here		- existing node in "tree"
  * direction	- either AVL_AFTER or AVL_BEFORE the data "here".
  */
-void avl_insert_here(avl_tree_t *tree, void *new_data, void *here,
+void fiber_avl_insert_here(fiber_avl_tree_t *tree, void *new_data, void *here,
     int direction);
 
 
@@ -197,8 +197,8 @@ void avl_insert_here(avl_tree_t *tree, void *new_data, void *here,
  * if the tree is empty.
  *
  */
-void *avl_first(avl_tree_t *tree);
-void *avl_last(avl_tree_t *tree);
+void *fiber_avl_first(fiber_avl_tree_t *tree);
+void *fiber_avl_last(fiber_avl_tree_t *tree);
 
 
 /*
@@ -208,33 +208,33 @@ void *avl_last(avl_tree_t *tree);
  *
  * node   - the node from which the next or previous node is found
  */
-#define	AVL_NEXT(tree, node)	avl_walk(tree, node, AVL_AFTER)
-#define	AVL_PREV(tree, node)	avl_walk(tree, node, AVL_BEFORE)
+#define	AVL_NEXT(tree, node)	fiber_avl_walk(tree, node, AVL_AFTER)
+#define	AVL_PREV(tree, node)	fiber_avl_walk(tree, node, AVL_BEFORE)
 
 
 /*
  * Find the node with the nearest value either greater or less than
- * the value from a previous avl_find(). Returns the node or NULL if
+ * the value from a previous fiber_avl_find(). Returns the node or NULL if
  * there isn't a matching one.
  *
- * where     - position as returned from avl_find()
+ * where     - position as returned from fiber_avl_find()
  * direction - either AVL_BEFORE or AVL_AFTER
  *
  * EXAMPLE get the greatest node that is less than a given value:
  *
- *	avl_tree_t *tree;
+ *	fiber_avl_tree_t *tree;
  *	struct my_data look_for_value = {....};
  *	struct my_data *node;
  *	struct my_data *less;
- *	avl_index_t where;
+ *	fiber_avl_index_t where;
  *
- *	node = avl_find(tree, &look_for_value, &where);
+ *	node = fiber_avl_find(tree, &look_for_value, &where);
  *	if (node != NULL)
  *		less = AVL_PREV(tree, node);
  *	else
- *		less = avl_nearest(tree, where, AVL_BEFORE);
+ *		less = fiber_avl_nearest(tree, where, AVL_BEFORE);
  */
-void *avl_nearest(avl_tree_t *tree, avl_index_t where, int direction);
+void *fiber_avl_nearest(fiber_avl_tree_t *tree, fiber_avl_index_t where, int direction);
 
 
 /*
@@ -244,7 +244,7 @@ void *avl_nearest(avl_tree_t *tree, avl_index_t where, int direction);
  *
  * node   - the node to add
  */
-void avl_add(avl_tree_t *tree, void *node);
+void fiber_avl_add(fiber_avl_tree_t *tree, void *node);
 
 
 /*
@@ -252,28 +252,28 @@ void avl_add(avl_tree_t *tree, void *node);
  *
  * node   - the node to remove
  */
-void avl_remove(avl_tree_t *tree, void *node);
+void fiber_avl_remove(fiber_avl_tree_t *tree, void *node);
 
 /*
  * Reinsert a node only if its order has changed relative to its nearest
- * neighbors. To optimize performance avl_update_lt() checks only the previous
- * node and avl_update_gt() checks only the next node. Use avl_update_lt() and
- * avl_update_gt() only if you know the direction in which the order of the
+ * neighbors. To optimize performance fiber_avl_update_lt() checks only the previous
+ * node and fiber_avl_update_gt() checks only the next node. Use fiber_avl_update_lt() and
+ * fiber_avl_update_gt() only if you know the direction in which the order of the
  * node may change.
  */
-boolean_t avl_update(avl_tree_t *, void *);
-boolean_t avl_update_lt(avl_tree_t *, void *);
-boolean_t avl_update_gt(avl_tree_t *, void *);
+boolean_t fiber_avl_update(fiber_avl_tree_t *, void *);
+boolean_t fiber_avl_update_lt(fiber_avl_tree_t *, void *);
+boolean_t fiber_avl_update_gt(fiber_avl_tree_t *, void *);
 
 /*
  * Return the number of nodes in the tree
  */
-ulong_t avl_numnodes(avl_tree_t *tree);
+ulong_t fiber_avl_numnodes(fiber_avl_tree_t *tree);
 
 /*
  * Return B_TRUE if there are zero nodes in the tree, B_FALSE otherwise.
  */
-boolean_t avl_is_empty(avl_tree_t *tree);
+boolean_t fiber_avl_is_empty(fiber_avl_tree_t *tree);
 
 /*
  * Used to destroy any remaining nodes in a tree. The cookie argument should
@@ -281,22 +281,22 @@ boolean_t avl_is_empty(avl_tree_t *tree);
  * removed from the tree and may be free()'d. Returns NULL when the tree is
  * empty.
  *
- * Once you call avl_destroy_nodes(), you can only continuing calling it and
- * finally avl_destroy(). No other AVL routines will be valid.
+ * Once you call fiber_avl_destroy_nodes(), you can only continuing calling it and
+ * finally fiber_avl_destroy(). No other AVL routines will be valid.
  *
- * cookie - a "void *" used to save state between calls to avl_destroy_nodes()
+ * cookie - a "void *" used to save state between calls to fiber_avl_destroy_nodes()
  *
  * EXAMPLE:
- *	avl_tree_t *tree;
+ *	fiber_avl_tree_t *tree;
  *	struct my_data *node;
  *	void *cookie;
  *
  *	cookie = NULL;
- *	while ((node = avl_destroy_nodes(tree, &cookie)) != NULL)
+ *	while ((node = fiber_avl_destroy_nodes(tree, &cookie)) != NULL)
  *		free(node);
- *	avl_destroy(tree);
+ *	fiber_avl_destroy(tree);
  */
-void *avl_destroy_nodes(avl_tree_t *tree, void **cookie);
+void *fiber_avl_destroy_nodes(fiber_avl_tree_t *tree, void **cookie);
 
 
 /*
@@ -304,7 +304,7 @@ void *avl_destroy_nodes(avl_tree_t *tree, void **cookie);
  *
  * tree   - the empty tree to destroy
  */
-void avl_destroy(avl_tree_t *tree);
+void fiber_avl_destroy(fiber_avl_tree_t *tree);
 
 #ifdef	__cplusplus
 }

--- a/c/src/common/avl_impl.h
+++ b/c/src/common/avl_impl.h
@@ -84,9 +84,9 @@ extern "C" {
 
 #ifndef _LP64
 
-struct avl_node {
-	struct avl_node *avl_child[2];	/* left/right children */
-	struct avl_node *avl_parent;	/* this node's parent */
+struct fiber_avl_node {
+	struct fiber_avl_node *avl_child[2];	/* left/right children */
+	struct fiber_avl_node *avl_parent;	/* this node's parent */
 	unsigned short avl_child_index;	/* my index in parent's avl_child[] */
 	short avl_balance;		/* balance value: -1, 0, +1 */
 };
@@ -114,8 +114,8 @@ struct avl_node {
  *
  */
 
-struct avl_node {
-	struct avl_node *avl_child[2];	/* left/right children nodes */
+struct fiber_avl_node {
+	struct fiber_avl_node *avl_child[2];	/* left/right children nodes */
 	uintptr_t avl_pcb;		/* parent, child_index, balance */
 };
 
@@ -124,7 +124,7 @@ struct avl_node {
  *
  * pointer to the parent of the current node is the high order bits
  */
-#define	AVL_XPARENT(n)		((struct avl_node *)((n)->avl_pcb & ~7))
+#define	AVL_XPARENT(n)		((struct fiber_avl_node *)((n)->avl_pcb & ~7))
 #define	AVL_SETPARENT(n, p)						\
 	((n)->avl_pcb = (((n)->avl_pcb & 7) | (uintptr_t)(p)))
 
@@ -153,23 +153,23 @@ struct avl_node {
  * the value of "o" is tree->avl_offset
  */
 #define	AVL_NODE2DATA(n, o)	((void *)((uintptr_t)(n) - (o)))
-#define	AVL_DATA2NODE(d, o)	((struct avl_node *)((uintptr_t)(d) + (o)))
+#define	AVL_DATA2NODE(d, o)	((struct fiber_avl_node *)((uintptr_t)(d) + (o)))
 
 /*
- * macros used to create/access an avl_index_t
+ * macros used to create/access an fiber_avl_index_t
  */
-#define	AVL_INDEX2NODE(x)	((avl_node_t *)((x) & ~1))
+#define	AVL_INDEX2NODE(x)	((fiber_avl_node_t *)((x) & ~1))
 #define	AVL_INDEX2CHILD(x)	((x) & 1)
-#define	AVL_MKINDEX(n, c)	((avl_index_t)(n) | (c))
+#define	AVL_MKINDEX(n, c)	((fiber_avl_index_t)(n) | (c))
 
 
 /*
  * The tree structure. The fields avl_root, avl_compar, and avl_offset come
- * first since they are needed for avl_find().  We want them to fit into
- * a single 64 byte cache line to make avl_find() as fast as possible.
+ * first since they are needed for fiber_avl_find().  We want them to fit into
+ * a single 64 byte cache line to make fiber_avl_find() as fast as possible.
  */
-struct avl_tree {
-	struct avl_node *avl_root;	/* root node in tree */
+struct fiber_avl_tree {
+	struct fiber_avl_node *avl_root;	/* root node in tree */
 	int (*avl_compar)(const void *, const void *);
 	size_t avl_offset;		/* offsetof(type, avl_link_t field) */
 	ulong_t avl_numnodes;		/* number of nodes in the tree */
@@ -180,7 +180,7 @@ struct avl_tree {
 /*
  * This will only by used via AVL_NEXT() or AVL_PREV()
  */
-void *avl_walk(struct avl_tree *, void *, int);
+void *fiber_avl_walk(struct fiber_avl_tree *, void *, int);
 
 #ifdef	__cplusplus
 }

--- a/c/src/common/pthread_patch.c
+++ b/c/src/common/pthread_patch.c
@@ -326,7 +326,7 @@ long thread_self(void)
 	return (long) GetCurrentThreadId();
 }
 
-#elif	defined(__linux__)
+#elif	defined(__linux__) || defined(COSMOCC)
 
 #include <sys/syscall.h>
 

--- a/c/src/common/timer_cache.h
+++ b/c/src/common/timer_cache.h
@@ -14,15 +14,16 @@ typedef struct TIMER_CACHE TIMER_CACHE;
 
 struct TIMER_CACHE_NODE {
 	RING ring;
-	avl_node_t node;
+	fiber_avl_node_t node;
 	long long expire;
 };
 
 struct TIMER_CACHE {
-	avl_tree_t tree;
+	fiber_avl_tree_t tree;
 	RING caches;		// Caching the TIMER_CACHE_NODE memory
 	int cache_max;
 	ARRAY *objs;		// Holding any object temporarily.
+	ARRAY *objs2;		// Holding any object temporarily.
 };
 
 TIMER_CACHE *timer_cache_create(void);
@@ -32,8 +33,9 @@ void timer_cache_add(TIMER_CACHE *cache, long long expire, RING *entry);
 int  timer_cache_remove(TIMER_CACHE *cache, long long expire, RING *entry);
 void timer_cache_free_node(TIMER_CACHE *cache, TIMER_CACHE_NODE *node);
 int timer_cache_remove_exist(TIMER_CACHE *cache, long long expire, RING *entry);
+int timer_cache_exist(TIMER_CACHE *cache, long long expire, RING *entry);
 
-#define TIMER_FIRST(cache) ((TIMER_CACHE_NODE*) avl_first(&(cache)->tree))
+#define TIMER_FIRST(cache) ((TIMER_CACHE_NODE*) fiber_avl_first(&(cache)->tree))
 #define TIMER_NEXT(cache, curr) ((TIMER_CACHE_NODE*) AVL_NEXT(&(cache)->tree, (curr)))
 
 #ifdef __cplusplus

--- a/c/src/define.h
+++ b/c/src/define.h
@@ -1,7 +1,7 @@
 #ifndef	__DEFINE_INCLUDE_H__
 #define	__DEFINE_INCLUDE_H__
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(LINUX2)
 # define LINUX
 # define SYS_UNIX
 # define HAS_SELECT

--- a/c/src/dns/rfc1035.c
+++ b/c/src/dns/rfc1035.c
@@ -1018,11 +1018,13 @@ static size_t save_addr2rr(int type, const char *src, RFC1035_RR *rr)
 		in6.sin6_port   = htons(0);
 
 #if defined(SYS_UNIX) || (defined(SYS_WIN) && _MSC_VER >= 1600)
+# if !defined(COSMOCC)
 		if (ptr && *ptr && !(in6.sin6_scope_id = if_nametoindex(ptr))) {
 			msg_error("%s(%d): if_nametoindex error %s",
 				__FUNCTION__, __LINE__, last_serror());
 			return 0;
 		}
+# endif
 #endif
 		if (inet_pton(AF_INET6, buf, &in6.sin6_addr) == 0) {
 			msg_error("%s(%d): invalid addr=%s",

--- a/c/src/event/event_epoll.c
+++ b/c/src/event/event_epoll.c
@@ -7,7 +7,14 @@
 #define __USE_GNU
 #endif
 #include <dlfcn.h>
-#include <sys/epoll.h>
+
+#ifdef COSMOCC
+# include <libc/sysv/consts/epoll.h>
+# include <libc/sock/epoll.h>
+#else
+# include <sys/epoll.h>
+#endif
+
 #include "event.h"
 #include "event_epoll.h"
 

--- a/c/src/event/event_io_uring.c
+++ b/c/src/event/event_io_uring.c
@@ -190,7 +190,7 @@ static int event_uring_add_write(EVENT_URING *ep, FILE_EVENT *fe)
 
 		TRY_SUBMMIT(ep);
 	} else if (fe->mask & EVENT_POLLOUT) {
-		add_write_wait(ep, fe, fe->r_timeout);
+		add_write_wait(ep, fe, fe->w_timeout);
 	} else if (fe->mask & EVENT_CONNECT) {
 		non_blocking(fe->fd, 1);
 		struct io_uring_sqe *sqe = io_uring_get_sqe(&ep->ring);

--- a/c/src/fbase_event.c
+++ b/c/src/fbase_event.c
@@ -189,15 +189,15 @@ int fbase_event_wakeup(FIBER_BASE *fbase)
 		if (var_hook_sys_api) {
 #ifdef	HAS_EVENTFD
 			// The eventfd can only use write API.
-			ret = fiber_write(fbase->out, (char*) &n, sizeof(n));
+			ret = (int) fiber_write(fbase->out, (char*) &n, sizeof(n));
 #else
-			ret = fiber_send(fbase->out, (char*) &n, sizeof(n), 0);
+			ret = (int) fiber_send(fbase->out, (char*) &n, sizeof(n), 0);
 #endif
 		} else {
 #ifdef	HAS_EVENTFD
-			ret = acl_fiber_write(fd, (char*) &n, sizeof(n));
+			ret = (int) acl_fiber_write(fd, (char*) &n, sizeof(n));
 #else
-			ret = acl_fiber_send(fd, (char*) &n, sizeof(n), 0);
+			ret = (int) acl_fiber_send(fd, (char*) &n, sizeof(n), 0);
 #endif
 		}
 

--- a/c/src/fiber.h
+++ b/c/src/fiber.h
@@ -13,27 +13,6 @@ extern void makecontext(ucontext_t *ucp, void (*func)(), int argc, ...);
 #endif
 */
 
-enum {
-	FIBER_STATUS_NONE	= (0),
-	FIBER_STATUS_READY	= (1 << 0),
-	FIBER_STATUS_RUNNING	= (1 << 1),
-	FIBER_STATUS_SUSPEND	= (1 << 2),
-	FIBER_STATUS_EXITING	= (1 << 3),
-};
-
-enum {
-	FIBER_WAIT_NONE		= (0),
-	FIBER_WAIT_READ		= (1 << 1),
-	FIBER_WAIT_WRITE	= (1 << 2),
-	FIBER_WAIT_POLL		= (1 << 3),
-	FIBER_WAIT_EPOLL	= (1 << 4),
-	FIBER_WAIT_MUTEX	= (1 << 5),
-	FIBER_WAIT_COND		= (1 << 6),
-	FIBER_WAIT_LOCK		= (1 << 7),
-	FIBER_WAIT_SEM		= (1 << 8),
-	FIBER_WAIT_DELAY	= (1 << 9),
-};
-
 typedef struct {
 	void  *ctx;
 	void (*free_fn)(void *);
@@ -57,13 +36,13 @@ struct ACL_FIBER {
 	FIBER_BASE    *base;
 	RING           me;
 	long           tid;
-	unsigned int   fid;
+	unsigned       fid;
 	unsigned       slot;
 	long long      when;
-	int            errnum;
-	int            signum;
-	unsigned short status;
-	unsigned short wstatus;
+	int            errnum;	// The fiber's current errno.
+	int            signum;	// The signed number to the fiber.
+	unsigned short status;	// The fiber's status as FIBER_STATUS_XXX.
+	unsigned short wstatus;	// The fiber's waiting status as FIBER_WAIT_XXX.
 	unsigned int   oflag;	// The flags for creating fiber.
 	unsigned int   flag;	// The flags for the fiber's running status.
 
@@ -84,7 +63,40 @@ struct ACL_FIBER {
 
 	FIBER_LOCAL  **locals;
 	int            nlocal;
+
+#ifdef DEBUG_READY
+	int            cline;
+	int            lline;
+	char           ctag[32];
+	char           ltag[32];
+	long long      curr;
+	long long      last;
+	unsigned short lstatus;
+	unsigned short lwstatus;
+	unsigned int   lflag;
+	time_t         cost;
+	FILE_EVENT    *fe;
+#endif
 };
+
+#ifdef DEBUG_READY
+# define FIBER_READY(f) {                                                     \
+	if ((f)->ctag[0] != 0) {                                              \
+		SAFE_STRNCPY((f)->ltag, (f)->ctag, sizeof((f)->ltag));        \
+		(f)->lline    = (f)->cline;                                   \
+		(f)->last     = (f)->curr;                                    \
+		(f)->lstatus  = (f)->status;                                  \
+		(f)->lwstatus = (f)->wstatus;                                 \
+		(f)->lflag    = (f)->flag;                                    \
+	}                                                                     \
+	SAFE_STRNCPY((f)->ctag, __FUNCTION__, sizeof((f)->ctag));             \
+	(f)->cline = __LINE__;                                                \
+	SET_TIME((f)->curr);                                                  \
+	acl_fiber_ready((f));                                                 \
+}
+#else
+# define FIBER_READY(f) acl_fiber_ready((f))
+#endif
 
 /* in fiber.c */
 extern __thread int var_hook_sys_api;
@@ -129,8 +141,9 @@ int fiber_wait_read(FILE_EVENT *fe);
 int fiber_wait_write(FILE_EVENT *fe);
 
 EVENT *fiber_io_event(void);
-void fiber_timer_add(ACL_FIBER *fiber, unsigned milliseconds);
+void fiber_timer_add(ACL_FIBER *fiber, size_t milliseconds);
 int fiber_timer_del(ACL_FIBER *fiber);
+int fiber_timer_exist(ACL_FIBER *fiber);
 
 FILE_EVENT *fiber_file_open(socket_t fd);
 void fiber_file_set(FILE_EVENT *fe);

--- a/c/src/file_event.c
+++ b/c/src/file_event.c
@@ -31,9 +31,9 @@ void file_event_init(FILE_EVENT *fe, socket_t fd)
 	memset(&fe->var, 0, sizeof(fe->var));
 	memset(&fe->reader_ctx, 0, sizeof(fe->reader_ctx));
 	memset(&fe->writer_ctx, 0, sizeof(fe->writer_ctx));
+#endif
 	fe->r_timeout = -1;
 	fe->w_timeout = -1;
-#endif
 
 #ifdef HAS_IOCP
 	fe->rbuf    = NULL;

--- a/c/src/hook/fiber_read.c
+++ b/c/src/hook/fiber_read.c
@@ -6,6 +6,7 @@
 #include "io.h"
 
 #if defined(HAS_IO_URING)
+
 static int uring_wait_read(FILE_EVENT *fe)
 {
 	while (1) {
@@ -30,13 +31,16 @@ static int uring_wait_read(FILE_EVENT *fe)
 			return fe->reader_ctx.res;
 		}
 
-		err = acl_fiber_last_error();
+		// Use the negative of res as the error.
+		err = -fe->reader_ctx.res;
+		acl_fiber_set_error(err);
 		fiber_save_errno(err);
 
 		if (!error_again(err)) {
-			if (!(fe->type & TYPE_EVENTABLE)) {
-				fiber_file_free(fe);
-			}
+			// Don't free fe here, which will be freed in close.
+			//if (!(fe->type & TYPE_EVENTABLE)) {
+			//	fiber_file_free(fe);
+			//}
 			return -1;
 		}
 	}
@@ -60,9 +64,9 @@ int fiber_iocp_read(FILE_EVENT *fe, char *buf, int len)
 
 	return iocp_wait_read(fe);
 }
-#endif  // HAS_IO_URING
 
-#if defined(HAS_IOCP)
+#elif defined(HAS_IOCP)
+
 static int iocp_wait_read(FILE_EVENT *fe)
 {
 	while (1) {
@@ -122,7 +126,8 @@ int fiber_iocp_read(FILE_EVENT *fe, char *buf, int len)
 	fe->res   = 0;
 	return iocp_wait_read(fe);
 }
-#endif // HAS_IOCP
+
+#endif // HAS_IOCP || HAS_IO_URING
 
 // After calling fiber_wait_read():
 // The fiber_wait_read will return three status:
@@ -148,7 +153,8 @@ int fiber_iocp_read(FILE_EVENT *fe, char *buf, int len)
 // not monitor the file fd in fiber_wait_read.
 
 #if defined(_WIN32) || defined(_WIN64)
-#define FIBER_READ(_fn, _fe, ...) do {                                       \
+
+# define FIBER_READ(_fn, _fe, ...) do {                                      \
     ssize_t ret;                                                             \
     int err;                                                                 \
     if (IS_READABLE((_fe))) {                                                \
@@ -172,8 +178,10 @@ int fiber_iocp_read(FILE_EVENT *fe, char *buf, int len)
         return -1;                                                           \
     }                                                                        \
 } while (1)
+
 #else
-#define FIBER_READ(_fn, _fe, _args...) do {                                  \
+
+# define FIBER_READ(_fn, _fe, _args...) do {                                 \
     ssize_t ret;                                                             \
     int err;                                                                 \
     if (IS_READABLE((_fe))) {                                                \
@@ -197,12 +205,13 @@ int fiber_iocp_read(FILE_EVENT *fe, char *buf, int len)
         return -1;                                                           \
     }                                                                        \
 } while (1)
+
 #endif
 
 #define FILE_ALLOC(f, t, fd) do {                                            \
     (f) = file_event_alloc(fd);                                              \
-    (f)->mask = (t);                                                       \
-    (f)->type = TYPE_EVENTABLE;                                            \
+    (f)->mask = (t);                                                         \
+    (f)->type = TYPE_EVENTABLE;                                              \
 } while (0)
 
 #ifdef SYS_UNIX
@@ -212,18 +221,18 @@ ssize_t fiber_read(FILE_EVENT *fe,  void *buf, size_t count)
 	CLR_POLLING(fe);
 
 #ifdef HAS_IO_URING
-	// One FILE_EVENT can be used by multiple fibers with the same
-	// EVENT_BUSY_READ or EVENT_BUSY_WRITE in the same time. But can be
-	// used by two fibers that one is a reader and the other is a writer,
-	// because there're two different objects for reader and writer.
-	if (EVENT_IS_IO_URING(fiber_io_event())) {
 
-#define SET_READ(f) do {                                                     \
+# define SET_READ(f) do {                                                    \
     (f)->in.read_ctx.buf = buf;                                              \
     (f)->in.read_ctx.len = (int) count;                                      \
     (f)->mask |= EVENT_READ;                                                 \
 } while (0)
 
+	// One FILE_EVENT can be used by multiple fibers with the same
+	// EVENT_BUSY_READ or EVENT_BUSY_WRITE in the same time. But can be
+	// used by two fibers that one is a reader and the other is a writer,
+	// because there're two different objects for reader and writer.
+	if (EVENT_IS_IO_URING(fiber_io_event())) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_READ)) {
@@ -251,15 +260,15 @@ ssize_t fiber_readv(FILE_EVENT *fe, const struct iovec *iov, int iovcnt)
 	CLR_POLLING(fe);
 
 #ifdef HAS_IO_URING
-	if (EVENT_IS_IO_URING(fiber_io_event())) {
 
-#define SET_READV(f) do {                                                    \
+# define SET_READV(f) do {                                                   \
     (f)->in.readv_ctx.iov = iov;                                             \
     (f)->in.readv_ctx.cnt = iovcnt;                                          \
     (f)->in.readv_ctx.off = 0;                                               \
     (f)->mask |= EVENT_READV;                                                \
 } while (0)
 
+	if (EVENT_IS_IO_URING(fiber_io_event())) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_READ)) {
@@ -287,14 +296,14 @@ ssize_t fiber_recvmsg(FILE_EVENT *fe, struct msghdr *msg, int flags)
 	CLR_POLLING(fe);
 
 #ifdef HAS_IO_URING
-	if (EVENT_IS_IO_URING(fiber_io_event())) {
 
-#define SET_RECVMSG(f) do {                                                  \
+# define SET_RECVMSG(f) do {                                                 \
     (f)->in.recvmsg_ctx.msg   = msg;                                         \
     (f)->in.recvmsg_ctx.flags = flags;                                       \
     (f)->mask |= EVENT_RECVMSG;                                              \
 } while (0)
 
+	if (EVENT_IS_IO_URING(fiber_io_event())) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_READ)) {
@@ -318,6 +327,7 @@ ssize_t fiber_recvmsg(FILE_EVENT *fe, struct msghdr *msg, int flags)
 }
 
 # ifdef HAS_MMSG
+
 ssize_t fiber_recvmmsg(FILE_EVENT *fe, struct mmsghdr *msgvec,
 	unsigned int vlen, int flags, const struct timespec *timeout)
 {
@@ -336,6 +346,7 @@ ssize_t fiber_recvmmsg(FILE_EVENT *fe, struct mmsghdr *msgvec,
 
 	FIBER_READ(sys_recvmmsg, fe, msgvec, vlen, flags, NULL);
 }
+
 # endif // HAS_MMSG
 
 #endif  // SYS_UNIX
@@ -346,18 +357,22 @@ ssize_t fiber_recv(FILE_EVENT *fe, void *buf, size_t len, int flags)
 
 #if defined(HAS_IOCP)
 	if (EVENT_IS_IOCP(fiber_io_event())) {
+# ifdef SYS_WIN
+		return (ssize_t) fiber_iocp_read(fe, buf, (int) len);
+# else
 		return fiber_iocp_read(fe, buf, len);
+# endif
 	}
 #elif defined(HAS_IO_URING)
-	if (EVENT_IS_IO_URING(fiber_io_event())) {
 
-#define SET_RECV(f) do {                                                     \
+# define SET_RECV(f) do {                                                    \
     (f)->in.recv_ctx.buf   = buf;                                            \
     (f)->in.recv_ctx.len   = (unsigned) len;                                 \
     (f)->in.recv_ctx.flags = flags;                                          \
     (f)->mask |= EVENT_RECV;                                                 \
 } while (0)
 
+	if (EVENT_IS_IO_URING(fiber_io_event())) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_READ)) {
@@ -377,7 +392,11 @@ ssize_t fiber_recv(FILE_EVENT *fe, void *buf, size_t len, int flags)
 	}
 #endif
 
+#ifdef SYS_WIN
+	FIBER_READ(sys_recv, fe, buf, (int) len, flags);
+#else
 	FIBER_READ(sys_recv, fe, buf, len, flags);
+#endif
 }
 
 ssize_t fiber_recvfrom(FILE_EVENT *fe, void *buf, size_t len,
@@ -387,12 +406,11 @@ ssize_t fiber_recvfrom(FILE_EVENT *fe, void *buf, size_t len,
 
 #if  defined(HAS_IOCP)
 	if (EVENT_IS_IOCP(fiber_io_event())) {
-		return fiber_iocp_read(fe, buf, len);
+		return fiber_iocp_read(fe, buf, (int) len);
 	}
 #elif  defined(HAS_IO_URING) && defined(IO_URING_HAS_RECVFROM)
-	if (EVENT_IS_IO_URING(fiber_io_event())) {
 
-#define SET_RECVFROM(f) do {                                                 \
+# define SET_RECVFROM(f) do {                                                \
     (f)->in.recvfrom_ctx.buf      = buf;                                     \
     (f)->in.recvfrom_ctx.len      = (unsigned) len;                          \
     (f)->in.recvfrom_ctx.flags    = flags;                                   \
@@ -401,6 +419,7 @@ ssize_t fiber_recvfrom(FILE_EVENT *fe, void *buf, size_t len,
     (f)->mask |= EVENT_RECVFROM;                                             \
 } while (0)
 
+	if (EVENT_IS_IO_URING(fiber_io_event())) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_READ)) {
@@ -420,5 +439,9 @@ ssize_t fiber_recvfrom(FILE_EVENT *fe, void *buf, size_t len,
 	}
 #endif
 
+#ifdef SYS_WIN
+	FIBER_READ(sys_recvfrom, fe, buf, (int) len, flags, src_addr, addrlen);
+#else
 	FIBER_READ(sys_recvfrom, fe, buf, len, flags, src_addr, addrlen);
+#endif
 }

--- a/c/src/hook/fiber_write.c
+++ b/c/src/hook/fiber_write.c
@@ -10,6 +10,7 @@
 // from connecting process.
 
 #if defined(HAS_IO_URING)
+
 # define CHECK_SET_NBLOCK(_fd) do {                                          \
     if (var_hook_sys_api && !EVENT_IS_IO_URING(fiber_io_event())) {          \
         FILE_EVENT *_fe = fiber_file_get(_fd);                               \
@@ -19,7 +20,9 @@
         }                                                                    \
     }                                                                        \
 } while (0)
+
 #else
+
 # define CHECK_SET_NBLOCK(_fd) do {                                          \
     if (var_hook_sys_api) {                                                  \
         FILE_EVENT *_fe = fiber_file_get(_fd);                               \
@@ -29,14 +32,17 @@
         }                                                                    \
     }                                                                        \
 } while (0)
-#endif
+
+#endif  // HAS_IO_URING
 
 static int wait_write(FILE_EVENT *fe)
 {
 	CLR_POLLING(fe);
 
 	if (fiber_wait_write(fe) < 0) {
-		fiber_file_free(fe);
+		// Bugfix: Don't free fe here, or crash will happen!.
+		// --zsx, 2024.10.25.
+		// fiber_file_free(fe);
 		return -1;
 	}
 
@@ -50,7 +56,8 @@ static int wait_write(FILE_EVENT *fe)
 }
 
 #if defined(HAS_IO_URING)
-static int iocp_wait_write(FILE_EVENT *fe)
+
+static int uring_wait_write(FILE_EVENT *fe)
 {
 	while (1) {
 		int err;
@@ -71,22 +78,22 @@ static int iocp_wait_write(FILE_EVENT *fe)
 		fiber_save_errno(err);
 
 		if (!error_again(err)) {
-			if (!(fe->type & TYPE_EVENTABLE)) {
-				fiber_file_free(fe);
-			}
+			// Don't free fe here, which will be freed in close.
+			//if (!(fe->type & TYPE_EVENTABLE)) {
+			//	fiber_file_free(fe);
+			//}
 			return -1;
 		}
 	}
 }
-#endif
 
-#if defined(HAS_IO_URING)
-int fiber_iocp_write(FILE_EVENT *fe, const char *buf, int len)
+int fiber_uring_write(FILE_EVENT *fe, const char *buf, int len)
 {
 	fe->out.write_ctx.buf = buf;
 	fe->out.write_ctx.len = len;
-	return iocp_wait_write(fe);
+	return uring_wait_write(fe);
 }
+
 #endif // HAS_IO_URING
 
 #define CHECK_WRITE_RESULT(_fe, _n) do {                                     \
@@ -110,34 +117,34 @@ int fiber_iocp_write(FILE_EVENT *fe, const char *buf, int len)
     (__fe)->type   = TYPE_EVENTABLE;                                         \
 } while (0)
 
-
 #ifdef SYS_UNIX
+
 ssize_t fiber_write(FILE_EVENT *fe, const void *buf, size_t count)
 {
 	CLR_POLLING(fe);
 
 #if defined(HAS_IO_URING)
-	if (EVENT_IS_IO_URING(fiber_io_event()) && !(fe->mask & EVENT_SYSIO)) {
 
-#define SET_WRITE(f) do {                                                    \
+# define SET_WRITE(f) do {                                                   \
     (f)->out.write_ctx.buf = buf;                                            \
     (f)->out.write_ctx.len = (unsigned) count;                               \
     (f)->mask |= EVENT_WRITE;                                                \
 } while (0)
 
+	if (EVENT_IS_IO_URING(fiber_io_event()) && !(fe->mask & EVENT_SYSIO)) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_WRITE)) {
 			SET_WRITE(fe);
 
 			fe->busy |= EVENT_BUSY_WRITE;
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			fe->busy &= ~EVENT_BUSY_WRITE;
 		} else {
 			FILE_ALLOC(fe, 0, fe->fd);
 			SET_WRITE(fe);
 
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			file_event_unrefer(fe);
 		}
 		return ret;
@@ -162,28 +169,28 @@ ssize_t fiber_writev(FILE_EVENT *fe, const struct iovec *iov, int iovcnt)
 	CLR_POLLING(fe);
 
 #if defined(HAS_IO_URING)
-	if (EVENT_IS_IO_URING(fiber_io_event())) {
 
-#define SET_WRITEV(f) do {                                                   \
+# define SET_WRITEV(f) do {                                                  \
     (f)->out.writev_ctx.iov = iov;                                           \
     (f)->out.writev_ctx.cnt = iovcnt;                                        \
     (f)->out.writev_ctx.off = 0;                                             \
     (f)->mask |= EVENT_WRITEV;                                               \
 } while (0)
 
+	if (EVENT_IS_IO_URING(fiber_io_event())) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_WRITE)) {
 			SET_WRITEV(fe);
 
 			fe->busy |= EVENT_BUSY_WRITE;
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			fe->busy &= ~EVENT_BUSY_WRITE;
 		} else {
 			FILE_ALLOC(fe, 0, fe->fd);
 			SET_WRITEV(fe);
 
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			file_event_unrefer(fe);
 		}
 		return ret;
@@ -209,28 +216,28 @@ ssize_t fiber_send(FILE_EVENT *fe, const void *buf, size_t len, int flags)
 	CLR_POLLING(fe);
 
 #if defined(HAS_IO_URING)
-	if (EVENT_IS_IO_URING(fiber_io_event())) {
 
-#define SET_SEND(f) do {                                                     \
+# define SET_SEND(f) do {                                                    \
     (f)->out.send_ctx.buf   = buf;                                           \
     (f)->out.send_ctx.len   = (unsigned) len;                                \
     (f)->out.send_ctx.flags = flags;                                         \
     (f)->mask |= EVENT_SEND;                                                 \
 } while (0)
 
+	if (EVENT_IS_IO_URING(fiber_io_event())) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_WRITE)) {
 			SET_SEND(fe);
 
 			fe->busy |= EVENT_BUSY_WRITE;
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			fe->busy &= ~EVENT_BUSY_WRITE;
 		} else {
 			FILE_ALLOC(fe, 0, fe->fd);
 			SET_SEND(fe);
 
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			file_event_unrefer(fe);
 		}
 		return ret;
@@ -244,7 +251,11 @@ ssize_t fiber_send(FILE_EVENT *fe, const void *buf, size_t len, int flags)
 	CHECK_SET_NBLOCK(fe->fd);
 
 	while (1) {
+#ifdef SYS_WIN
+		int n = (int) (*sys_send)(fe->fd, buf, (int) len, flags);
+#else
 		int n = (int) (*sys_send)(fe->fd, buf, len, flags);
+#endif
 
 		CHECK_WRITE_RESULT(fe, n);
 	}
@@ -256,9 +267,8 @@ ssize_t fiber_sendto(FILE_EVENT *fe, const void *buf, size_t len,
 	CLR_POLLING(fe);
 
 #if defined(HAS_IO_URING) && defined(IO_URING_HAS_SENDTO)
-	if (EVENT_IS_IO_URING(fiber_io_event())) {
 
-#define SET_SENDTO(f) do {                                                   \
+# define SET_SENDTO(f) do {                                                  \
     (f)->out.sendto_ctx.buf       = buf;                                     \
     (f)->out.sendto_ctx.len       = (unsigned) len;                          \
     (f)->out.sendto_ctx.flags     = flags;                                   \
@@ -267,19 +277,20 @@ ssize_t fiber_sendto(FILE_EVENT *fe, const void *buf, size_t len,
     (f)->mask |= EVENT_SENDTO;                                               \
 } while (0)
 
+	if (EVENT_IS_IO_URING(fiber_io_event())) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_WRITE)) {
 			SET_SENDTO(fe);
 
 			fe->busy |= EVENT_BUSY_WRITE;
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			fe->busy &= ~EVENT_BUSY_WRITE;
 		} else {
 			FILE_ALLOC(fe, 0, fe->fd);
 			SET_SENDTO(fe);
 
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			file_event_unrefer(fe);
 		}
 		return ret;
@@ -293,40 +304,46 @@ ssize_t fiber_sendto(FILE_EVENT *fe, const void *buf, size_t len,
 	CHECK_SET_NBLOCK(fe->fd);
 
 	while (1) {
+#ifdef SYS_WIN
+		int n = (int) (*sys_sendto)(fe->fd, buf, (int) len, flags,
+				dest_addr, addrlen);
+#else
 		int n = (int) (*sys_sendto)(fe->fd, buf, len, flags,
 				dest_addr, addrlen);
+#endif
 
 		CHECK_WRITE_RESULT(fe, n);
 	}
 }
 
 #ifdef SYS_UNIX
+
 ssize_t fiber_sendmsg(FILE_EVENT *fe, const struct msghdr *msg, int flags)
 {
 	CLR_POLLING(fe);
 
 #if defined(HAS_IO_URING)
-	if (EVENT_IS_IO_URING(fiber_io_event())) {
 
-#define SET_SENDMSG(f) do {                                                  \
+# define SET_SENDMSG(f) do {                                                 \
     (f)->out.sendmsg_ctx.msg   = msg;                                        \
     (f)->out.sendmsg_ctx.flags = flags;                                      \
     (f)->mask |= EVENT_SENDMSG;                                              \
 } while (0)
 
+	if (EVENT_IS_IO_URING(fiber_io_event())) {
 		int ret;
 
 		if (!(fe->busy & EVENT_BUSY_WRITE)) {
 			SET_SENDMSG(fe);
 
 			fe->busy |= EVENT_BUSY_WRITE;
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			fe->busy &= ~EVENT_BUSY_WRITE;
 		} else {
 			FILE_ALLOC(fe, 0, fe->fd);
 			SET_SENDMSG(fe);
 
-			ret = iocp_wait_write(fe);
+			ret = uring_wait_write(fe);
 			file_event_unrefer(fe);
 		}
 		return ret;
@@ -347,6 +364,7 @@ ssize_t fiber_sendmsg(FILE_EVENT *fe, const struct msghdr *msg, int flags)
 }
 
 # ifdef HAS_MMSG
+
 int fiber_sendmmsg(FILE_EVENT *fe, struct mmsghdr *msgvec, unsigned int vlen,
 	int flags)
 {

--- a/c/src/hook/file.c
+++ b/c/src/hook/file.c
@@ -37,7 +37,7 @@
 static void file_read_callback(EVENT *ev UNUSED, FILE_EVENT *fe)
 {
 	if (fe->fiber_r->status != FIBER_STATUS_READY) {
-		acl_fiber_ready(fe->fiber_r);
+		FIBER_READY(fe->fiber_r);
 	}
 }
 
@@ -504,7 +504,7 @@ ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
 
 	fe->fd = fd;
 	fe->out.write_ctx.off = offset;
-	ret = fiber_iocp_write(fe, buf, (int) count);
+	ret = fiber_uring_write(fe, buf, (int) count);
 	file_event_unrefer(fe);
 
 	return ret;

--- a/c/src/hook/getaddrinfo.c
+++ b/c/src/hook/getaddrinfo.c
@@ -41,11 +41,13 @@ static struct addrinfo *create_addrinfo(const char *ip, short port,
 		sa.in6.sin6_family = AF_INET6;
 		sa.in6.sin6_port   = htons(port);
 
+#ifndef COSMOCC
 		if (ptr && *ptr) {
 			if (!(in6->sin6_scope_id = if_nametoindex(ptr))) {
 				return NULL;
 			}
 		}
+#endif
 		if (inet_pton(AF_INET6, buf, &sa.in6.sin6_addr) <= 0) {
 			return NULL;
 		}

--- a/c/src/hook/hook.c
+++ b/c/src/hook/hook.c
@@ -2,138 +2,144 @@
 #include "common.h"
 #include "hook.h"
 
-socket_fn     __sys_socket                  = NULL;
-socket_fn     *sys_socket                   = NULL;
+static socket_fn         __sys_socket              = NULL;
+socket_fn                *sys_socket               = NULL;
 
-close_fn      __sys_close                   = NULL;
-close_fn      *sys_close                    = NULL;
+static close_fn          __sys_close               = NULL;
+close_fn                 *sys_close                = NULL;
 
-listen_fn     __sys_listen                  = NULL;
-listen_fn     *sys_listen                   = NULL;
+static listen_fn         __sys_listen              = NULL;
+listen_fn                *sys_listen               = NULL;
 
-accept_fn     __sys_accept                  = NULL;
-accept_fn     *sys_accept                   = NULL;
+static accept_fn         __sys_accept              = NULL;
+accept_fn                *sys_accept               = NULL;
 
-connect_fn    __sys_connect                 = NULL;
-connect_fn    *sys_connect                  = NULL;
+static connect_fn        __sys_connect             = NULL;
+connect_fn               *sys_connect              = NULL;
 
-recv_fn       __sys_recv                    = NULL;
-recv_fn       *sys_recv                     = NULL;
+static recv_fn           __sys_recv                = NULL;
+recv_fn                  *sys_recv                 = NULL;
 
-recvfrom_fn   __sys_recvfrom                = NULL;
-recvfrom_fn   *sys_recvfrom                 = NULL;
+static recvfrom_fn       __sys_recvfrom            = NULL;
+recvfrom_fn              *sys_recvfrom             = NULL;
 
-send_fn       __sys_send                    = NULL;
-send_fn       *sys_send                     = NULL;
+static send_fn           __sys_send                = NULL;
+send_fn                  *sys_send                 = NULL;
 
-sendto_fn     __sys_sendto                  = NULL;
-sendto_fn     *sys_sendto                   = NULL;
+static sendto_fn         __sys_sendto              = NULL;
+sendto_fn                *sys_sendto               = NULL;
 
-poll_fn       __sys_poll                    = NULL;
-poll_fn       *sys_poll                     = NULL;
+static poll_fn           __sys_poll                = NULL;
+poll_fn                  *sys_poll                 = NULL;
 
-select_fn     __sys_select                  = NULL;
-select_fn     *sys_select                   = NULL;
+static select_fn         __sys_select              = NULL;
+select_fn                *sys_select               = NULL;
 
-getaddrinfo_fn   __sys_getaddrinfo          = NULL;
-getaddrinfo_fn   *sys_getaddrinfo           = NULL;
+static getaddrinfo_fn    __sys_getaddrinfo         = NULL;
+getaddrinfo_fn           *sys_getaddrinfo          = NULL;
 
-freeaddrinfo_fn  __sys_freeaddrinfo         = NULL;
-freeaddrinfo_fn  *sys_freeaddrinfo          = NULL;
+static freeaddrinfo_fn   __sys_freeaddrinfo        = NULL;
+freeaddrinfo_fn          *sys_freeaddrinfo         = NULL;
 
-gethostbyname_fn __sys_gethostbyname        = NULL;
-gethostbyname_fn *sys_gethostbyname         = NULL;
+static gethostbyname_fn  __sys_gethostbyname       = NULL;
+gethostbyname_fn         *sys_gethostbyname        = NULL;
 
 #ifdef SYS_UNIX
 
-sleep_fn    __sys_sleep                     = NULL;
-sleep_fn    *sys_sleep                      = NULL;
+static sleep_fn          __sys_sleep               = NULL;
+sleep_fn                 *sys_sleep                = NULL;
 
-fcntl_fn    __sys_fcntl                     = NULL;
-fcntl_fn    *sys_fcntl                      = NULL;
+static fcntl_fn          __sys_fcntl               = NULL;
+fcntl_fn                 *sys_fcntl                = NULL;
 
-setsockopt_fn __sys_setsockopt              = NULL;
-setsockopt_fn *sys_setsockopt               = NULL;
+static setsockopt_fn     __sys_setsockopt          = NULL;
+setsockopt_fn            *sys_setsockopt           = NULL;
 
-read_fn     __sys_read                      = NULL;
-read_fn     *sys_read                       = NULL;
+static getsockopt_fn     __sys_getsockopt          = NULL;
+getsockopt_fn            *sys_getsockopt           = NULL;
 
-readv_fn    __sys_readv                     = NULL;
-readv_fn    *sys_readv                      = NULL;
+static read_fn           __sys_read                = NULL;
+read_fn                  *sys_read                 = NULL;
 
-recvmsg_fn  __sys_recvmsg                   = NULL;
-recvmsg_fn  *sys_recvmsg                    = NULL;
+static readv_fn          __sys_readv               = NULL;
+readv_fn                 *sys_readv                = NULL;
 
-write_fn    __sys_write                     = NULL;
-write_fn    *sys_write                      = NULL;
+static recvmsg_fn        __sys_recvmsg             = NULL;
+recvmsg_fn               *sys_recvmsg              = NULL;
 
-writev_fn   __sys_writev                    = NULL;
-writev_fn   *sys_writev                     = NULL;
+static write_fn          __sys_write               = NULL;
+write_fn                 *sys_write                = NULL;
 
-sendmsg_fn  __sys_sendmsg                   = NULL;
-sendmsg_fn  *sys_sendmsg                    = NULL;
+static writev_fn         __sys_writev              = NULL;
+writev_fn                *sys_writev               = NULL;
+
+static sendmsg_fn        __sys_sendmsg             = NULL;
+sendmsg_fn               *sys_sendmsg              = NULL;
 
 # ifdef HAS_MMSG
-recvmmsg_fn  __sys_recvmmsg                 = NULL;
-recvmmsg_fn  *sys_recvmmsg                  = NULL;
+static recvmmsg_fn       __sys_recvmmsg            = NULL;
+recvmmsg_fn              *sys_recvmmsg             = NULL;
 
-sendmmsg_fn  __sys_sendmmsg                 = NULL;
-sendmmsg_fn  *sys_sendmmsg                  = NULL;
+static sendmmsg_fn       __sys_sendmmsg            = NULL;
+sendmmsg_fn              *sys_sendmmsg             = NULL;
 
 # endif
 
 # ifdef __USE_LARGEFILE64
-sendfile64_fn __sys_sendfile64              = NULL;
-sendfile64_fn *sys_sendfile64               = NULL;
+static sendfile64_fn      __sys_sendfile64         = NULL;
+sendfile64_fn             *sys_sendfile64          = NULL;
 # endif
 
-pread_fn      __sys_pread                   = NULL;
-pread_fn      *sys_pread                    = NULL;
-pwrite_fn     __sys_pwrite                  = NULL;
-pwrite_fn     *sys_pwrite                   = NULL;
+static pread_fn           __sys_pread              = NULL;
+pread_fn                  *sys_pread               = NULL;
+
+static pwrite_fn          __sys_pwrite             = NULL;
+pwrite_fn                 *sys_pwrite              = NULL;
 
 # ifdef HAS_EPOLL
-epoll_create_fn __sys_epoll_create          = NULL;
-epoll_create_fn *sys_epoll_create           = NULL;
+static epoll_create_fn    __sys_epoll_create       = NULL;
+epoll_create_fn           *sys_epoll_create        = NULL;
 
-epoll_wait_fn   __sys_epoll_wait            = NULL;
-epoll_wait_fn   *sys_epoll_wait             = NULL;
+static epoll_wait_fn      __sys_epoll_wait         = NULL;
+epoll_wait_fn             *sys_epoll_wait          = NULL;
 
-epoll_ctl_fn    __sys_epoll_ctl             = NULL;
-epoll_ctl_fn    *sys_epoll_ctl              = NULL;
+static epoll_ctl_fn       __sys_epoll_ctl          = NULL;
+epoll_ctl_fn              *sys_epoll_ctl           = NULL;
 # endif
 
 # ifdef HAS_IO_URING
-openat_fn       __sys_openat                = NULL;
-openat_fn       *sys_openat                 = NULL;
-unlink_fn       __sys_unlink                = NULL;
-unlink_fn       *sys_unlink                 = NULL;
+static openat_fn          __sys_openat             = NULL;
+openat_fn                 *sys_openat              = NULL;
+
+static unlink_fn          __sys_unlink             = NULL;
+unlink_fn                 *sys_unlink              = NULL;
 # ifdef HAS_STATX
-statx_fn        __sys_statx                 = NULL;
-statx_fn        *sys_statx                  = NULL;
+static statx_fn           __sys_statx              = NULL;
+statx_fn                  *sys_statx               = NULL;
 # endif
 # ifdef HAS_RENAMEAT2
-renameat2_fn    __sys_renameat2             = NULL;
-renameat2_fn    *sys_renameat2              = NULL;
+static renameat2_fn       __sys_renameat2          = NULL;
+renameat2_fn              *sys_renameat2           = NULL;
 # endif
-mkdirat_fn      __sys_mkdirat               = NULL;
-mkdirat_fn      *sys_mkdirat                = NULL;
-splice_fn       __sys_splice                = NULL;
-splice_fn       *sys_splice                 = NULL;
+static mkdirat_fn         __sys_mkdirat            = NULL;
+mkdirat_fn                *sys_mkdirat             = NULL;
+
+static splice_fn          __sys_splice             = NULL;
+splice_fn                 *sys_splice              = NULL;
 # endif
 
 # ifndef __APPLE__
-gethostbyname_r_fn __sys_gethostbyname_r    = NULL;
-gethostbyname_r_fn *sys_gethostbyname_r     = NULL;
+static gethostbyname_r_fn __sys_gethostbyname_r    = NULL;
+gethostbyname_r_fn        *sys_gethostbyname_r     = NULL;
 # endif
 
 #elif defined(SYS_WIN)
 
-WSARecv_fn __sys_WSARecv                     = NULL;
-WSARecv_fn *sys_WSARecv                      = NULL;
+static WSARecv_fn         __sys_WSARecv            = NULL;
+WSARecv_fn                *sys_WSARecv             = NULL;
 
-WSAAccept_fn __sys_WSAAccept                 = NULL;
-WSAAccept_fn *sys_WSAAccept                  = NULL;
+static WSAAccept_fn       __sys_WSAAccept          = NULL;
+WSAAccept_fn              *sys_WSAAccept           = NULL;
 
 #endif // SYS_WIN
 
@@ -250,6 +256,7 @@ static void hook_api(void)
 	LOAD_FN("accept", accept_fn, __sys_accept, sys_accept, 1);
 	LOAD_FN("connect", connect_fn, __sys_connect, sys_connect, 1);
 	LOAD_FN("setsockopt", setsockopt_fn, __sys_setsockopt, sys_setsockopt, 1);
+	LOAD_FN("getsockopt", getsockopt_fn, __sys_getsockopt, sys_getsockopt, 1);
 	LOAD_FN("sleep", sleep_fn, __sys_sleep, sys_sleep, 1);
 	LOAD_FN("fcntl", fcntl_fn, __sys_fcntl, sys_fcntl, 1);
 	LOAD_FN("read", read_fn, __sys_read, sys_read, 1);

--- a/c/src/hook/hook.h
+++ b/c/src/hook/hook.h
@@ -3,6 +3,13 @@
 
 #include "fiber/fiber_define.h"
 
+#ifdef COSMOCC
+# include <libc/sysv/consts/epoll.h>
+# include <libc/sock/epoll.h>
+#elif defined(__linux__) || defined(LINUX2)
+# include <sys/epoll.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -35,10 +42,11 @@ typedef int (WSAAPI *WSARecv_fn)(socket_t, LPWSABUF, DWORD, LPDWORD, LPDWORD,
 typedef socket_t (WSAAPI *WSAAccept_fn)(SOCKET, struct sockaddr FAR *,
     LPINT, LPCONDITIONPROC, DWORD_PTR);
 
-#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(MINGW)
+#elif defined(__linux__) || defined(LINUX2) || defined(__APPLE__) || defined(__FreeBSD__) || defined(MINGW)
 
 typedef int (*fcntl_fn)(int, int, ...);
 typedef int (*setsockopt_fn)(socket_t, int, int, const void *, socklen_t);
+typedef int (*getsockopt_fn)(socket_t, int, int, void *, socklen_t*);
 typedef unsigned (*sleep_fn)(unsigned int seconds);
 typedef ssize_t  (*read_fn)(socket_t, void *, size_t);
 typedef ssize_t  (*readv_fn)(socket_t, const struct iovec *, int);
@@ -143,10 +151,11 @@ extern gethostbyname_fn     *sys_gethostbyname;
 extern WSARecv_fn           *sys_WSARecv;
 extern WSAAccept_fn         *sys_WSAAccept;
 
-#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)  || defined(MINGW) // SYS_UNIX
+#elif defined(__linux__) || defined(LINUX2) || defined(__APPLE__) || defined(__FreeBSD__)  || defined(MINGW) // SYS_UNIX
 
 extern fcntl_fn             *sys_fcntl;
 extern setsockopt_fn        *sys_setsockopt;
+extern getsockopt_fn        *sys_getsockopt;
 extern sleep_fn             *sys_sleep;
 
 extern read_fn              *sys_read;
@@ -197,7 +206,7 @@ extern pwrite_fn            *sys_pwrite;
 // in hook.c
 void hook_once(void);
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(LINUX2)
 // in epoll.c
 int epoll_try_register(int epfd);
 int epoll_close(int epfd);

--- a/c/src/hook/io.h
+++ b/c/src/hook/io.h
@@ -20,7 +20,7 @@ ssize_t fiber_sendto(FILE_EVENT *fe, const void *buf, size_t len,
 	int flags, const struct sockaddr *dest_addr, socklen_t addrlen);
 ssize_t fiber_sendmsg(FILE_EVENT *fe, const struct msghdr *msg, int flags);
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)  || defined(MINGW) // SYS_UNIX
+#if defined(__linux__) || defined(LINUX2) || defined(__APPLE__) || defined(__FreeBSD__)  || defined(MINGW) // SYS_UNIX
 
 // in fiber_read.c
 int fiber_iocp_read(FILE_EVENT *fe, char *buf, int len);
@@ -34,7 +34,7 @@ ssize_t fiber_recvmmsg(FILE_EVENT *fe, struct mmsghdr *msgvec,
 # endif
 
 // in fiber_write.c
-int fiber_iocp_write(FILE_EVENT *fe, const char *buf, int len);
+int fiber_uring_write(FILE_EVENT *fe, const char *buf, int len);
 
 ssize_t fiber_write(FILE_EVENT *fe, const void *buf, size_t count);
 ssize_t fiber_writev(FILE_EVENT *fe, const struct iovec *iov, int iovcnt);

--- a/c/src/hook/select.c
+++ b/c/src/hook/select.c
@@ -178,7 +178,7 @@ int acl_fiber_select(int nfds, fd_set *readfds, fd_set *writefds,
 	return nready;
 }
 
-#ifdef SYS_UNIX
+#if defined(SYS_UNIX) && !defined(DISABLE_HOOK)
 int select(int nfds, fd_set *readfds, fd_set *writefds,
 	fd_set *exceptfds, struct timeval *timeout)
 {

--- a/c/src/hook/socket.c
+++ b/c/src/hook/socket.c
@@ -484,18 +484,20 @@ int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 	return acl_fiber_connect(sockfd, addr, addrlen);
 }
 
+#ifdef CREAT_TIMER_FIBER
+
 typedef struct TIMEOUT_CTX {
 	ACL_FIBER *fiber;
 	int        sockfd;
 	unsigned   id;
 } TIMEOUT_CTX;
 
-static void fiber_timeout(ACL_FIBER *fiber UNUSED, void *ctx)
+static void read_timeout(ACL_FIBER *fiber UNUSED, void *ctx)
 {
 	TIMEOUT_CTX *tc = (TIMEOUT_CTX*) ctx;
 	FILE_EVENT *fe = fiber_file_get(tc->sockfd);
 
-	// we must check the fiber carefully here.
+	// We must check the fiber carefully here.
 	if (fe == NULL || tc->fiber != fe->fiber_r
 		|| tc->fiber->fid != fe->fiber_r->fid) {
 
@@ -503,10 +505,9 @@ static void fiber_timeout(ACL_FIBER *fiber UNUSED, void *ctx)
 		return;
 	}
 
-	// we can kill the fiber only if the fiber is waiting
+	// We can kill the fiber only if the fiber is waiting
 	// for readable ore writable of IO process.
-	if (fe->fiber_r->wstatus & (FIBER_WAIT_READ | FIBER_WAIT_WRITE)) {
-
+	if (fe->fiber_r->wstatus & FIBER_WAIT_READ) {
 		tc->fiber->errnum = FIBER_EAGAIN;
 		acl_fiber_signal(tc->fiber, SIGINT);
 	}
@@ -514,26 +515,55 @@ static void fiber_timeout(ACL_FIBER *fiber UNUSED, void *ctx)
 	mem_free(ctx);
 }
 
+static void send_timeout(ACL_FIBER *fiber UNUSED, void *ctx)
+{
+	TIMEOUT_CTX *tc = (TIMEOUT_CTX*) ctx;
+	FILE_EVENT *fe = fiber_file_get(tc->sockfd);
+
+	// We must check the fiber carefully here.
+	if (fe == NULL || tc->fiber != fe->fiber_w
+		|| tc->fiber->fid != fe->fiber_w->fid) {
+
+		mem_free(ctx);
+		return;
+	}
+
+	// We can kill the fiber only if the fiber is waiting
+	// for readable ore writable of IO process.
+	if (fe->fiber_w->wstatus & FIBER_WAIT_READ) {
+		tc->fiber->errnum = FIBER_EAGAIN;
+		acl_fiber_signal(tc->fiber, SIGINT);
+	}
+
+	mem_free(ctx);
+}
+
+#endif  // CREAT_TIMER_FIBER
+
 int setsockopt(int sockfd, int level, int optname,
 	const void *optval, socklen_t optlen)
 {
 	size_t val;
+#ifdef CREAT_TIMER_FIBER
 	TIMEOUT_CTX *ctx;
+#else
+	FILE_EVENT *fe;
+	ACL_FIBER *curr;
+#endif
 	const struct timeval *tm;
 
 	if (sys_setsockopt == NULL) {
 		hook_once();
+
+		if (sys_setsockopt == NULL) {
+			msg_error("sys_setsockopt null");
+			return -1;
+		}
 	}
 
 	if (!var_hook_sys_api || (optname != SO_RCVTIMEO
 				&& optname != SO_SNDTIMEO)) {
-		return sys_setsockopt ? (*sys_setsockopt)(sockfd, level,
-			optname, optval, optlen) : -1;
-	}
-
-	if (sys_setsockopt == NULL) {
-		msg_error("sys_setsockopt null");
-		return -1;
+		return (*sys_setsockopt)(sockfd, level, optname, optval, optlen);
 	}
 
 	switch (optlen) {
@@ -557,15 +587,145 @@ int setsockopt(int sockfd, int level, int optname,
 		val = tm->tv_sec + tm->tv_usec / 1000000;
 		break;
 	default:
+		acl_fiber_set_error(FIBER_EINVAL);
 		msg_error("invalid optlen=%d", (int) optlen);
 		return -1;
 	}
 
+#ifdef CREAT_TIMER_FIBER
 	ctx = (TIMEOUT_CTX*) mem_malloc(sizeof(TIMEOUT_CTX));
 	ctx->fiber  = acl_fiber_running();
 	ctx->sockfd = sockfd;
-	acl_fiber_create_timer((unsigned) val * 1000, 64000, fiber_timeout, ctx);
+
+	if (optname == SO_RCVTIMEO) {
+		val *= 1000;
+		acl_fiber_create_timer(val, 4096, read_timeout, ctx);
+		return 0;
+	} else if (optname == SO_SNDTIMEO) {
+		val *= 1000;
+		acl_fiber_create_timer(val, 4096, send_timeout, ctx);
+		return 0;
+	} else {
+		msg_error("Invalid optname=%d", optname);
+		return -1;
+	}
+#else
+	curr = acl_fiber_running();
+	fe = fiber_file_open(sockfd);
+
+	if (val <= 0) {
+		fiber_timer_del(curr);
+		if (optname == SO_RCVTIMEO) {
+			fe->mask &= ~EVENT_SO_RCVTIMEO;
+			fe->r_timeout = -1;
+		} else if (optname == SO_SNDTIMEO) {
+			fe->mask &= ~EVENT_SO_SNDTIMEO;
+			fe->w_timeout = -1;
+		}
+		return 0;
+	}
+
+	val *= 1000;
+	if (optname == SO_RCVTIMEO) {
+		fe->mask |= EVENT_SO_RCVTIMEO;
+		fe->r_timeout = val;
+	} else if (optname == SO_SNDTIMEO) {
+		fe->mask |= EVENT_SO_SNDTIMEO;
+		fe->w_timeout = val;
+	} else {
+		msg_fatal("%s: Invalid optname=%d", __FUNCTION__, optname);
+	}
+
+	// We just set the flags here, and the timer will be add in
+	// fiber_wait_read or fiber_wait_write.
 	return 0;
+#endif
+}
+
+int getsockopt(int sockfd, int level, int optname,
+	void *optval, socklen_t *optlen)
+{
+	FILE_EVENT *fe;
+
+	if (sys_getsockopt == NULL) {
+		hook_once();
+
+		if (sys_getsockopt == NULL) {
+			msg_error("sys_getsockopt null");
+			return -1;
+		}
+	}
+
+	if (!var_hook_sys_api || (optname != SO_RCVTIMEO
+				&& optname != SO_SNDTIMEO)) {
+		return (*sys_getsockopt)(sockfd, level, optname, optval, optlen);
+	}
+
+	if (optval == NULL || optlen == NULL) {
+		acl_fiber_set_error(FIBER_EINVAL);
+		return -1;
+	}
+
+	fe = fiber_file_open(sockfd);
+
+#if defined(SYS_WIN)
+	if (*optlen < (socklen_t) sizeof(int)) {
+		acl_fiber_set_error(FIBER_EINVAL);
+		msg_error("optlen(%d) too short < %zd", (int) (*optlen), sizeof(int));
+		return -1;
+	}
+
+	if (optname == SO_RCVTIMEO) {
+		if (fe->r_timeout < 0) {
+			*((int*) optval) = fe->r_timeout;
+		} else {
+			*((int*) optval) = fe->r_timeout / 1000;
+		}
+	} else if (optname == SO_SNDTIMEO) {
+		if (fe->w_timeout < 0) {
+			*((int*) optval) = fe->w_timeout;
+		} else {
+			*((int*) optval) = fe->w_timeout / 1000;
+		}
+	} else {
+		return -1;  // xxx
+	}
+
+	*optlen = (socklen_t) sizeof(int);
+	return 0;
+#else
+	if (*optlen < (socklen_t) sizeof(struct timeval)) {
+		acl_fiber_set_error(FIBER_EINVAL);
+		msg_error("optlen(%d) too short < %zd",
+			(int) (*optlen), sizeof(struct timeval));
+		return -1;
+	}
+
+	if (optname == SO_RCVTIMEO) {
+		struct timeval *tm = (struct timeval*) optval;
+		if (fe->r_timeout < 0) {
+			tm->tv_sec  = 0;
+			tm->tv_usec = 0;
+		} else {
+			tm->tv_sec  = fe->r_timeout / 1000;
+			tm->tv_usec = 1000000 * (fe->r_timeout % 1000);
+		}
+	} else if (optname == SO_SNDTIMEO) {
+		struct timeval *tm = (struct timeval*) optval;
+		if (fe->w_timeout < 0) {
+			tm->tv_sec  = 0;
+			tm->tv_usec = 0;
+		} else {
+			tm->tv_sec  = fe->w_timeout / 1000;
+			tm->tv_usec = 1000000 * (fe->w_timeout % 1000);
+		}
+	} else {
+		return -1; // xxx
+	}
+
+	*optlen = (socklen_t) sizeof(struct timeval);
+	return 0;
+#endif
 }
 
 #endif

--- a/c/src/stdafx.h
+++ b/c/src/stdafx.h
@@ -14,7 +14,7 @@
 #endif
 
 #ifndef _GNU_SOURCE
-#define _GNU_SOURCE
+# define _GNU_SOURCE
 #endif
 
 #include <stdio.h>
@@ -56,15 +56,24 @@
 #define STRDUP strdup
 #define GETPID getpid
 
+// xxx: Don't use fstat to check fd's type, because in CentOS7.2, this maybe
+// make the OpenSSL blocked by mutex, and the reason hasn't been got yet.
+//#define USE_FSTAT_CHECKFD
+
 #elif defined(SYS_WIN)
 
 #define STRDUP _strdup
 #define GETPID _getpid
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(LINUX2)
 # include <sys/sendfile.h>
-# include <sys/epoll.h>
+# ifdef COSMOCC
+#  include <libc/sysv/consts/epoll.h>
+#  include <libc/sock/epoll.h>
+# else
+#  include <sys/epoll.h>
+# endif
 
 /*
 # if !defined(__aarch64__) && !defined(__arm__)

--- a/c/src/sync/channel.c
+++ b/c/src/sync/channel.c
@@ -252,7 +252,7 @@ static void alt_exec(FIBER_ALT *a)
 		alt_all_dequeue(other->xalt);
 		other->xalt[0].xalt = other;
 
-		acl_fiber_ready(other->fiber);
+		FIBER_READY(other->fiber);
 	 } else
 		alt_copy(a, NULL);
 }

--- a/c/src/sync/fiber_cond.c
+++ b/c/src/sync/fiber_cond.c
@@ -165,6 +165,13 @@ static int fiber_cond_timedwait(ACL_FIBER_COND *cond, ACL_FIBER_MUTEX *mutex,
 		return FIBER_ETIME;
 	}
 
+	if (acl_fiber_canceled(fiber)) {
+		acl_fiber_set_errno(fiber, FIBER_ECANCELED);
+		acl_fiber_set_error(FIBER_ECANCELED);
+		sync_obj_unrefer(obj);
+		return FIBER_ECANCELED;
+	}
+
 	sync_obj_unrefer(obj);
 	return 0;
 }

--- a/c/src/sync/fiber_lock.c
+++ b/c/src/sync/fiber_lock.c
@@ -118,7 +118,7 @@ void acl_fiber_lock_unlock(ACL_FIBER_LOCK *lk)
 
 	if ((lk->owner = ready) != NULL) {
 		ring_detach(&ready->me);
-		acl_fiber_ready(ready);
+		FIBER_READY(ready);
 		acl_fiber_yield();
 	}
 }
@@ -242,7 +242,7 @@ void acl_fiber_rwlock_runlock(ACL_FIBER_RWLOCK *lk)
 	if (--lk->readers == 0 && (fiber = FIRST_FIBER(&lk->wwaiting))) {
 		ring_detach(&lk->wwaiting);
 		lk->writer = fiber;
-		acl_fiber_ready(fiber);
+		FIBER_READY(fiber);
 		acl_fiber_yield();
 	}
 }
@@ -267,14 +267,14 @@ void acl_fiber_rwlock_wunlock(ACL_FIBER_RWLOCK *lk)
 	while ((fiber = FIRST_FIBER(&lk->rwaiting)) != NULL) {
 		ring_detach(&lk->rwaiting);
 		lk->readers++;
-		acl_fiber_ready(fiber);
+		FIBER_READY(fiber);
 		n++;
 	}
 
 	if (lk->readers == 0 && (fiber = FIRST_FIBER(&lk->wwaiting)) != NULL) {
 		ring_detach(&lk->wwaiting);
 		lk->writer = fiber;
-		acl_fiber_ready(fiber);
+		FIBER_READY(fiber);
 		n++;
 	}
 

--- a/c/src/sync/fiber_mutex.c
+++ b/c/src/sync/fiber_mutex.c
@@ -344,17 +344,17 @@ void acl_fiber_mutex_stats_free(ACL_FIBER_MUTEX_STATS *stats)
 	mem_free(stats);
 }
 
-static void show_mutex_stat(const ACL_FIBER_MUTEX_STAT *stat)
+static void show_mutex_stat(const ACL_FIBER_MUTEX_STAT *s)
 {
 	size_t i;
 
-	printf("fiber-%d\r\n", acl_fiber_id(stat->fiber));
-	show_stack(stat->fiber);
+	printf("fiber-%d\r\n", acl_fiber_id(s->fiber));
+	show_stack(s->fiber);
 
-	for (i = 0; i < stat->count; i++) {
-		printf("Holding mutex=%p\r\n", stat->holding[i]);
+	for (i = 0; i < s->count; i++) {
+		printf("Holding mutex=%p\r\n", s->holding[i]);
 	}
-	printf("Waiting for mutex=%p\r\n", stat->waiting);
+	printf("Waiting for mutex=%p\r\n", s->waiting);
 }
 
 void acl_fiber_mutex_stats_show(const ACL_FIBER_MUTEX_STATS *stats)
@@ -612,7 +612,7 @@ int acl_fiber_mutex_unlock(ACL_FIBER_MUTEX *mutex)
 
 	if (fiber) {
 		if (thread_self() == fiber->tid) {
-			acl_fiber_ready(fiber);
+			FIBER_READY(fiber);
 		} else {
 			sync_waiter_wakeup(fiber->sync, fiber);
 		}

--- a/c/src/sync/fiber_sem.c
+++ b/c/src/sync/fiber_sem.c
@@ -172,7 +172,7 @@ int acl_fiber_sem_post(ACL_FIBER_SEM *sem)
 	}
 
 	ring_detach(&ready->me);
-	acl_fiber_ready(ready);
+	FIBER_READY(ready);
 
 	/* Help the fiber to be wakeup to decrease the sem number. */
 	num = sem->num--;

--- a/c/src/sync/sync_timer.c
+++ b/c/src/sync/sync_timer.c
@@ -72,12 +72,14 @@ static void wakeup_waiter(SYNC_TIMER *timer UNUSED, SYNC_OBJ *obj)
 	// The fiber must has been awakened by the other fiber or thread.
 
 	if (obj->delay < 0) {
-		// No timer has been set if delay < 0, 
-		acl_fiber_ready(obj->fb);
+		// No timer has been set if delay < 0,
+		ring_detach(&obj->fb->me);  // Safety detatch me from others.
+		FIBER_READY(obj->fb);
 	} else if (fiber_timer_del(obj->fb) == 1) {
 		// Wakeup the waiting fiber before the timer arrives,
 		// just remove it from the timer.
-		acl_fiber_ready(obj->fb);
+		ring_detach(&obj->fb->me);  // Safety detatch me from others.
+		FIBER_READY(obj->fb);
 	}
 	// else: The fiber has been awakened by the timer.
 }

--- a/c/src/sync/sync_waiter.c
+++ b/c/src/sync/sync_waiter.c
@@ -72,7 +72,7 @@ static void fiber_waiting(ACL_FIBER *fiber fiber_unused, void *ctx)
 		ACL_FIBER *fb = mbox_read(waiter->box, delay, &res);
 		if (fb) {
 			assert(fb->status == FIBER_STATUS_SUSPEND);
-			acl_fiber_ready(fb);
+			FIBER_READY(fb);
 		}
 	}
 }

--- a/cpp/include/fiber/channel.hpp
+++ b/cpp/include/fiber/channel.hpp
@@ -12,32 +12,26 @@ int channel_send(ACL_CHANNEL *c, void *v);
 int channel_recv(ACL_CHANNEL *c, void *v);
 
 template <typename T>
-class channel
-{
+class channel {
 public:
-	channel(void)
-	{
+	channel(void) {
 		chan_ = channel_create(sizeof(T), 100);
 	}
 
-	~channel(void)
-	{
+	~channel(void) {
 		channel_free(chan_);
 	}
 
-	channel& operator << (T& t)
-	{
+	channel& operator << (T& t) {
 		return put(t);
 	}
 
-	channel& put(T& t)
-	{
+	channel& put(T& t) {
 		channel_send(chan_, &t);
 		return *this;
 	}
 
-	void pop(T& t)
-	{
+	void pop(T& t) {
 		channel_recv(chan_, &t);
 	}
 

--- a/cpp/include/fiber/fiber.hpp
+++ b/cpp/include/fiber/fiber.hpp
@@ -17,8 +17,8 @@ typedef enum {
 } fiber_event_t;
 
 struct FIBER_CPP_API fiber_frame {
-	fiber_frame(void) : pc(0), off(0) {}
-	~fiber_frame(void) {}
+	fiber_frame() : pc(0), off(0) {}
+	~fiber_frame() {}
 
 	std::string func;
 	long pc;
@@ -30,7 +30,7 @@ struct FIBER_CPP_API fiber_frame {
  */
 class FIBER_CPP_API fiber {
 public:
-	fiber(void);
+	fiber();
 	fiber(ACL_FIBER *fb);
 
 	/**
@@ -42,7 +42,7 @@ public:
 	 */
 	fiber(bool running);
 
-	virtual ~fiber(void);
+	virtual ~fiber();
 
 	/**
 	 * 在创建一个协程类对象且构造参数 running 为 false 时，需要本函数启动
@@ -56,15 +56,17 @@ public:
 
 	/**
 	 * 在本协程运行时调用此函数通知该协程退出
+	 * @param sync {bool} 是否采用同步方式，即是否等待被 kill 协程返回后
+	 *  本协程才返回
 	 * @return {bool} 返回 false 表示本协程未启动或已经退出
 	 */
-	bool kill(void);
+	bool kill(bool sync = false);
 
 	/**
 	 * 判断当前协程是否被通知退出
 	 * @return {bool} 本协程是否被通知退出
 	 */
-	bool killed(void) const;
+	bool killed() const;
 
 	/**
 	 * 判断当前正在运行的协程是否被通知退出，该方法与 killed 的区别为，
@@ -73,19 +75,19 @@ public:
 	 * 当前正在运行的协程
 	 * @return {bool}
 	 */
-	static bool self_killed(void);
+	static bool self_killed();
 
 	/**
 	 * 获得本协程对象的 ID 号
 	 * @return {unsigned int}
 	 */
-	unsigned int get_id(void) const;
+	unsigned int get_id() const;
 
 	/**
 	 * 获得当前运行的协程对象的 ID 号
 	 * @return {unsigned int}
 	 */
-	static unsigned int self(void);
+	static unsigned int self();
 
 	/**
 	 * 获得指定协程对象的ID号
@@ -97,7 +99,19 @@ public:
 	 * 获得当前协程在执行某个系统 API 出错时的错误号
 	 * return {int}
 	 */
-	int get_errno(void) const;
+	int get_errno() const;
+
+	/**
+	 * 判断协程是否处于待调度队列中
+	 * @return {bool}
+	 */
+	bool is_ready() const;
+
+	/**
+	 * 判断协程是否处于挂起状态
+	 *
+	 */
+	bool is_suspended() const;
 
 	/**
 	 * 设置当前协程的错误号
@@ -108,20 +122,20 @@ public:
 	/**
 	 * 清除当前协程的错误号及标记位
 	 */
-	static void clear(void);
+	static void clear();
 
 public:
 	/**
 	 * 获得本次操作的出错信息
 	 * @return {const char*}
 	 */
-	static const char* last_serror(void);
+	static const char* last_serror();
 
 	/**
 	 * 获得本次操作的出错号
 	 * @return {int}
 	 */
-	static int last_error(void);
+	static int last_error();
 
 	/**
 	 * 将所给错误号转成描述信息
@@ -154,8 +168,14 @@ public:
 	 *  部会自动启动协程调度器；否则，在创建并启动协程后，必须显式地调用
 	 *  schedule 或 schedule_with 方式来启动协程调度器以运行所的协程过程；
 	 *  内部缺省状态为 false
+	 * @param backend_fiber {bool} 当事件类型为FIBER_EVENT_T_WMSG，
 	 */
 	static void init(fiber_event_t type, bool schedule_auto = false);
+
+	/**
+	 * 在 Windows 平台下，可以调用此方法启用 GUI 界面协程模式
+	 */
+	static void schedule_gui();
 
 	/**
 	 * 启动协程运行的调度过程
@@ -174,23 +194,23 @@ public:
 	 * 判断当前线程是否处于协程调度状态
 	 * @return {bool}
 	 */
-	static bool scheduled(void);
+	static bool scheduled();
 
 	/**
 	 *  停止协程调度过程
 	 */
-	static void schedule_stop(void);
+	static void schedule_stop();
 
 public:
 	/**
 	 * 将当前正在运行的协程(即本协程) 挂起
 	 */
-	static void yield(void);
+	static void yield();
 
 	/**
 	 * 挂起当前协程，执行等待队列中的下一个协程
 	 */
-	static void switch_to_next(void);
+	static void switch_to_next();
 
 	/**
 	 * 将指定协程对象置入待运行队列中
@@ -200,22 +220,22 @@ public:
 
 	/**
 	 * 使当前运行的协程休眠指定毫秒数
-	 * @param milliseconds {unsigned int} 指定要休眠的毫秒数
-	 * @return {unsigned int} 本协程休眠后再次被唤醒后剩余的毫秒数
+	 * @param milliseconds {size_t} 指定要休眠的毫秒数
+	 * @return {size_t} 本协程休眠后再次被唤醒后剩余的毫秒数
 	 */
-	static unsigned int delay(unsigned int milliseconds);
+	static size_t delay(size_t milliseconds);
 
 	/**
 	 * 获得处于存活状态的协程数量
 	 * @return {unsigned}
 	 */
-	static unsigned alive_number(void);
+	static unsigned alive_number();
 
 	/**
 	 * 获得处于退出状态的协程对象数量
 	 * @return {unsigned}
 	 */
-	static unsigned dead_number(void);
+	static unsigned dead_number();
 
 	/**
 	 * 设置本线程中所有协程在连接服务端时都采用了带超时的非阻塞方式（仅限Windows)
@@ -233,30 +253,19 @@ public:
 	 * 在启用共享栈模式下获得共享栈大小
 	 * @return {size_t} 如果返回 0 则表示未启用共享栈方式
 	 */
-	static size_t get_shared_stack_size(void);
-
-	/**
-	 * 显式调用本函数使 acl 基础库的 IO 过程协程化，在 UNIX 平台下不必显式
-	 * 调用本函数，因为内部会自动 HOOK IO API
-	 */
-	static void acl_io_hook(void);
-
-	/**
-	 * 调用本函数取消 acl基础库中的 IO 协程化
-	 */
-	static void acl_io_unlock(void);
+	static size_t get_shared_stack_size();
 
 	/**
 	 * Windows 平台下可以显式地调用此函数 Hook 一些与网络协程相关的系统 API
 	 * @return {bool}
 	 */
-	static bool winapi_hook(void);
+	static bool winapi_hook();
 
 	/**
 	 * 获得当前系统级错误号
 	 * @return {int}
 	 */
-	static int  get_sys_errno(void);
+	static int  get_sys_errno();
 
 	/**
 	 * 设置当前系统级错误号
@@ -269,7 +278,7 @@ public:
 	 * 返回本协程对象对应的 C 语言的协程对象
 	 * @return {ACL_FIBER* }
 	 */
-	ACL_FIBER* get_fiber(void) const;
+	ACL_FIBER* get_fiber() const;
 
 	/**
 	 * 底层调用 C API 创建协程
@@ -304,7 +313,7 @@ protected:
 	 * 虚函数将会被调用，从而通知子类协程已启动; 如果在构造函数中的参数
 	 * running 为 true ，则 start 将被禁止调用，故本虚方法也不会被调用
 	 */
-	virtual void run(void);
+	virtual void run();
 
 private:
 	ACL_FIBER* f_;
@@ -320,8 +329,8 @@ private:
  */
 class FIBER_CPP_API fiber_timer {
 public:
-	fiber_timer(void);
-	virtual ~fiber_timer(void) {}
+	fiber_timer();
+	virtual ~fiber_timer() {}
 
 	/**
 	 * 启动一个协程定时器
@@ -334,7 +343,7 @@ protected:
 	/**
 	 * 子类必须实现该纯虚方法，当定时器启动时会回调该方法
 	 */
-	virtual void run(void) = 0;
+	virtual void run() = 0;
 
 private:
 	ACL_FIBER* f_;
@@ -360,7 +369,7 @@ public:
 	{
 	}
 
-	virtual ~fiber_trigger(void) {}
+	virtual ~fiber_trigger() {}
 
 	void add(T* o) {
 		mbox_.push(o);
@@ -370,12 +379,12 @@ public:
 		timer_.del(o);
 	}
 
-	timer_trigger<T>& get_trigger(void) {
+	timer_trigger<T>& get_trigger() {
 		return timer_;
 	}
 
 	// @override
-	void run(void) {
+	void run() {
 		while (!stop_) {
 			T* o = mbox_.pop(delay_);
 			if (o) {

--- a/cpp/include/fiber/fiber_tbox2.hpp
+++ b/cpp/include/fiber/fiber_tbox2.hpp
@@ -1,0 +1,171 @@
+#pragma once
+#include "fiber_cpp_define.hpp"
+#include <list>
+#include <stdlib.h>
+#include "fiber_mutex.hpp"
+#include "fiber_cond.hpp"
+
+namespace acl {
+
+/**
+ * 用于协程之间，线程之间以及协程与线程之间的消息通信，通过协程条件变量
+ * 及协程事件锁实现
+ *
+ * 示例：
+ *
+ * class myobj {
+ * public:
+ *     myobj(void) {}
+ *     ~myobj(void) {}
+ *
+ *     void test(void) { printf("hello world\r\n"); }
+ * };
+ *
+ * acl::fiber_tbox2<myobj> tbox;
+ *
+ * void thread_producer(void) {
+ *     myobj o;
+ *     tbox.push(o);
+ * }
+ *
+ * void thread_consumer(void) {
+ *     myobj o;
+
+ *     if (tbox.pop(o)) {
+ *         o.test();
+ *     }
+ * }
+ */
+
+// The fiber_tbox2 has an object copying process in push/pop which is suitable
+// for transfering the object managed by std::shared_ptr.
+
+template<typename T>
+class fiber_tbox2 {
+public:
+	/**
+	 * 构造方法
+	 */
+	fiber_tbox2(void) : size_(0) {}
+
+	~fiber_tbox2(void) {}
+
+	/**
+	 * 清理消息队列中未被消费的消息对象
+	 */
+	void clear(void) {
+		tbox_.clear();
+	}
+
+	/**
+	 * 发送消息对象
+	 * @param t {T} 消息对象
+	 * @param notify_first {bool} 如果本参数为 true，则内部添加完消息后
+	 *  采用先通知后解锁方式，否则采用先解锁后通知方式，当 fiber_tbox2 对象
+	 *  的生存周期比较长时，该参数设为 false 的效率更高，如果 fiber_tbox2
+	 *  对象的生存周期较短(如：等待者调用 pop 后直接销毁 fiber_tbox2 对象),
+	 *  则本参数应该设为 true，以避免 push 者还没有完全返回前因 fiber_tbox2
+	 *  对象被提前销毁而造成内存非法访问
+	 * @return {bool}
+	 */
+	bool push(T t, bool notify_first = true) {
+		// 先加锁
+		if (mutex_.lock() == false) {
+			abort();
+		}
+
+		// 向队列中添加消息对象
+		tbox_.push_back(t);
+		size_++;
+
+		if (notify_first) {
+			if (cond_.notify() == false) {
+				abort();
+			}
+			if (mutex_.unlock() == false) {
+				abort();
+			}
+			return true;
+		} else {
+			if (mutex_.unlock() == false) {
+				abort();
+			}
+			if (cond_.notify() == false) {
+				abort();
+			}
+			return true;
+		}
+	}
+
+	/**
+	 * 接收消息对象
+	 * @param t {T&} 当函数 返回 true 时存放结果对象
+	 * @param wait_ms {int} >= 0 时设置等待超时时间(毫秒级别)，
+	 *  否则永远等待直到读到消息对象或出错
+	 * @return {bool} 是否获得消息对象
+	 */
+	bool pop(T& t, int wait_ms = -1) {
+		if (mutex_.lock() == false) {
+			abort();
+		}
+		while (true) {
+			if (peek_obj(t)) {
+				if (mutex_.unlock() == false) {
+					abort();
+				}
+				return true;
+			}
+
+			if (!cond_.wait(mutex_, wait_ms) && wait_ms >= 0) {
+				if (mutex_.unlock() == false) {
+					abort();
+				}
+				return false;
+			}
+		}
+	}
+
+	/**
+	 * 返回当前存在于消息队列中的消息数量
+	 * @return {size_t}
+	 */
+	size_t size(void) const {
+		return size_;
+	}
+
+public:
+	void lock(void) {
+		if (mutex_.lock() == false) {
+			abort();
+		}
+	}
+
+	void unlock(void) {
+		if (mutex_.unlock() == false) {
+			abort();
+		}
+	}
+
+private:
+	fiber_tbox2(const fiber_tbox2&) {}
+	const fiber_tbox2& operator=(const fiber_tbox2&);
+
+private:
+	std::list<T>  tbox_;
+	size_t        size_;
+	fiber_mutex   mutex_;
+	fiber_cond    cond_;
+
+	bool peek_obj(T& t) {
+		typename std::list<T>::iterator it = tbox_.begin();
+		if (it == tbox_.end()) {
+			return false;
+		}
+		size_--;
+		t = *it;
+		tbox_.erase(it);
+		return true;
+	}
+};
+
+} // namespace acl

--- a/cpp/include/fiber/go_fiber.hpp
+++ b/cpp/include/fiber/go_fiber.hpp
@@ -12,7 +12,7 @@
 //    201703L (C++17)
 //    202002L (C++20)
 
-#if __cplusplus >= 201103L      // Support c++11 ?
+#if defined(USE_CPP11) || __cplusplus >= 201103L      // Support c++11 ?
 
 struct ACL_FIBER;
 

--- a/cpp/include/fiber/libfiber.hpp
+++ b/cpp/include/fiber/libfiber.hpp
@@ -5,5 +5,7 @@
 #include "fiber_event.hpp"
 #include "fiber_cond.hpp"
 #include "fiber_tbox.hpp"
+#include "fiber_tbox2.hpp"
+#include "wait_group.hpp"
 #include "fiber_sem.hpp"
 #include "channel.hpp"

--- a/cpp/include/fiber/wait_group.hpp
+++ b/cpp/include/fiber/wait_group.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "fiber_cpp_define.hpp"
+
+namespace acl {
+
+template<typename T> class fiber_tbox;
+
+class FIBER_CPP_API wait_group {
+public:
+	wait_group();
+	~wait_group();
+
+	void add(int n);
+	void done();
+	void wait();
+
+private:
+	void* state_;
+	long long n_;
+	fiber_tbox<unsigned long>* box_;
+};
+
+} // namespace acl

--- a/cpp/libfiber_cpp_vc2019.vcxproj
+++ b/cpp/libfiber_cpp_vc2019.vcxproj
@@ -287,10 +287,14 @@
     <ClInclude Include="include\fiber\fiber_cpp_define.hpp" />
     <ClInclude Include="include\fiber\fiber_event.hpp" />
     <ClInclude Include="include\fiber\fiber_lock.hpp" />
+    <ClInclude Include="include\fiber\fiber_mutex.hpp" />
+    <ClInclude Include="include\fiber\fiber_mutex_stat.hpp" />
     <ClInclude Include="include\fiber\fiber_sem.hpp" />
     <ClInclude Include="include\fiber\fiber_tbox.hpp" />
+    <ClInclude Include="include\fiber\fiber_tbox2.hpp" />
     <ClInclude Include="include\fiber\go_fiber.hpp" />
     <ClInclude Include="include\fiber\libfiber.hpp" />
+    <ClInclude Include="include\fiber\wait_group.hpp" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="src\detours\detours.h" />
     <ClInclude Include="src\detours\detver.h" />
@@ -308,6 +312,8 @@
     <ClCompile Include="src\fiber_cond.cpp" />
     <ClCompile Include="src\fiber_event.cpp" />
     <ClCompile Include="src\fiber_lock.cpp" />
+    <ClCompile Include="src\fiber_mutex.cpp" />
+    <ClCompile Include="src\fiber_mutex_stat.cpp" />
     <ClCompile Include="src\fiber_sem.cpp" />
     <ClCompile Include="src\stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -319,6 +325,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='DebugDll|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='DebugDll|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="src\wait_group.cpp" />
     <ClCompile Include="src\winapi_hook.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/cpp/libfiber_cpp_vc2019.vcxproj.filters
+++ b/cpp/libfiber_cpp_vc2019.vcxproj.filters
@@ -60,6 +60,15 @@
     <ClCompile Include="src\winapi_hook.cpp">
       <Filter>源文件</Filter>
     </ClCompile>
+    <ClCompile Include="src\fiber_mutex.cpp">
+      <Filter>源文件</Filter>
+    </ClCompile>
+    <ClCompile Include="src\fiber_mutex_stat.cpp">
+      <Filter>源文件</Filter>
+    </ClCompile>
+    <ClCompile Include="src\wait_group.cpp">
+      <Filter>源文件</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\stdafx.hpp">
@@ -105,6 +114,18 @@
       <Filter>头文件</Filter>
     </ClInclude>
     <ClInclude Include="resource.h">
+      <Filter>头文件</Filter>
+    </ClInclude>
+    <ClInclude Include="include\fiber\fiber_mutex.hpp">
+      <Filter>头文件</Filter>
+    </ClInclude>
+    <ClInclude Include="include\fiber\fiber_mutex_stat.hpp">
+      <Filter>头文件</Filter>
+    </ClInclude>
+    <ClInclude Include="include\fiber\fiber_tbox2.hpp">
+      <Filter>头文件</Filter>
+    </ClInclude>
+    <ClInclude Include="include\fiber\wait_group.hpp">
       <Filter>头文件</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cpp/src/detours/creatwth.cpp
+++ b/cpp/src/detours/creatwth.cpp
@@ -467,7 +467,7 @@ static BOOL RecordExeRestore(HANDLE hProcess, HMODULE hModule, DETOUR_EXE_RESTOR
 #define IMAGE_THUNK_DATAXX              IMAGE_THUNK_DATA32
 #define UPDATE_IMPORTS_XX               UpdateImports32
 #define DETOURS_BITS_XX                 32
-#include "uimports.cpp"
+#include "deps/uimports.cpp"
 #undef DETOUR_EXE_RESTORE_FIELD_XX
 #undef DWORD_XX
 #undef IMAGE_NT_HEADERS_XX
@@ -484,7 +484,7 @@ static BOOL RecordExeRestore(HANDLE hProcess, HMODULE hModule, DETOUR_EXE_RESTOR
 #define IMAGE_THUNK_DATAXX              IMAGE_THUNK_DATA64
 #define UPDATE_IMPORTS_XX               UpdateImports64
 #define DETOURS_BITS_XX                 64
-#include "uimports.cpp"
+#include "deps/uimports.cpp"
 #undef DETOUR_EXE_RESTORE_FIELD_XX
 #undef DWORD_XX
 #undef IMAGE_NT_HEADERS_XX

--- a/cpp/src/detours/deps/uimports.cpp
+++ b/cpp/src/detours/deps/uimports.cpp
@@ -1,0 +1,338 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  Add DLLs to a module import table (uimports.cpp of detours.lib)
+//
+//  Microsoft Research Detours Package, Version 4.0.1
+//
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//  Note that this file is included into creatwth.cpp one or more times
+//  (once for each supported module format).
+//
+
+#include "stdafx.hpp"
+// #define DETOUR_DEBUG 1
+#define DETOURS_INTERNAL
+#include "detours.h"
+
+#if DETOURS_VERSION != 0x4c0c1   // 0xMAJORcMINORcPATCH
+#error detours.h version mismatch
+#endif
+
+// UpdateImports32 aka UpdateImports64
+static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
+                              HMODULE hModule,
+                              __in_ecount(nDlls) LPCSTR *plpDlls,
+                              DWORD nDlls)
+{
+    BOOL fSucceeded = FALSE;
+    DWORD cbNew = 0;
+
+    BYTE * pbNew = NULL;
+    DWORD i;
+    SIZE_T cbRead;
+    DWORD n;
+
+    PBYTE pbModule = (PBYTE)hModule;
+
+    IMAGE_DOS_HEADER idh;
+    ZeroMemory(&idh, sizeof(idh));
+    if (!ReadProcessMemory(hProcess, pbModule, &idh, sizeof(idh), &cbRead)
+        || cbRead < sizeof(idh)) {
+
+        DETOUR_TRACE(("ReadProcessMemory(idh@%p..%p) failed: %lu\n",
+                      pbModule, pbModule + sizeof(idh), GetLastError()));
+
+      finish:
+        if (pbNew != NULL) {
+            delete[] pbNew;
+            pbNew = NULL;
+        }
+        return fSucceeded;
+    }
+
+    IMAGE_NT_HEADERS_XX inh;
+    ZeroMemory(&inh, sizeof(inh));
+
+    if (!ReadProcessMemory(hProcess, pbModule + idh.e_lfanew, &inh, sizeof(inh), &cbRead)
+        || cbRead < sizeof(inh)) {
+        DETOUR_TRACE(("ReadProcessMemory(inh@%p..%p) failed: %lu\n",
+                      pbModule + idh.e_lfanew,
+                      pbModule + idh.e_lfanew + sizeof(inh),
+                      GetLastError()));
+        goto finish;
+    }
+
+    if (inh.OptionalHeader.Magic != IMAGE_NT_OPTIONAL_HDR_MAGIC_XX) {
+        DETOUR_TRACE(("Wrong size image (%04x != %04x).\n",
+                      inh.OptionalHeader.Magic, IMAGE_NT_OPTIONAL_HDR_MAGIC_XX));
+        SetLastError(ERROR_INVALID_BLOCK);
+        goto finish;
+    }
+
+    // Zero out the bound table so loader doesn't use it instead of our new table.
+    inh.BOUND_DIRECTORY.VirtualAddress = 0;
+    inh.BOUND_DIRECTORY.Size = 0;
+
+    // Find the size of the mapped file.
+    DWORD dwSec = idh.e_lfanew +
+        FIELD_OFFSET(IMAGE_NT_HEADERS_XX, OptionalHeader) +
+        inh.FileHeader.SizeOfOptionalHeader;
+
+    for (i = 0; i < inh.FileHeader.NumberOfSections; i++) {
+        IMAGE_SECTION_HEADER ish;
+        ZeroMemory(&ish, sizeof(ish));
+
+        if (!ReadProcessMemory(hProcess, pbModule + dwSec + sizeof(ish) * i, &ish,
+                               sizeof(ish), &cbRead)
+            || cbRead < sizeof(ish)) {
+
+            DETOUR_TRACE(("ReadProcessMemory(ish@%p..%p) failed: %lu\n",
+                          pbModule + dwSec + sizeof(ish) * i,
+                          pbModule + dwSec + sizeof(ish) * (i + 1),
+                          GetLastError()));
+            goto finish;
+        }
+
+        DETOUR_TRACE(("ish[%lu] : va=%08lx sr=%lu\n", i, ish.VirtualAddress, ish.SizeOfRawData));
+        
+        // If the linker didn't suggest an IAT in the data directories, the
+        // loader will look for the section of the import directory to be used
+        // for this instead. Since we put out new IMPORT_DIRECTORY outside any
+        // section boundary, the loader will not find it. So we provide one
+        // explicitly to avoid the search.
+        //
+        if (inh.IAT_DIRECTORY.VirtualAddress == 0 &&
+            inh.IMPORT_DIRECTORY.VirtualAddress >= ish.VirtualAddress &&
+            inh.IMPORT_DIRECTORY.VirtualAddress < ish.VirtualAddress + ish.SizeOfRawData) {
+
+            inh.IAT_DIRECTORY.VirtualAddress = ish.VirtualAddress;
+            inh.IAT_DIRECTORY.Size = ish.SizeOfRawData;
+        }
+    }
+
+    if (inh.IMPORT_DIRECTORY.VirtualAddress != 0 && inh.IMPORT_DIRECTORY.Size == 0) {
+
+        // Don't worry about changing the PE file, 
+        // because the load information of the original PE header has been saved and will be restored. 
+        // The change here is just for the following code to work normally
+
+        PIMAGE_IMPORT_DESCRIPTOR pImageImport = (PIMAGE_IMPORT_DESCRIPTOR)(pbModule + inh.IMPORT_DIRECTORY.VirtualAddress);
+
+        do {
+            IMAGE_IMPORT_DESCRIPTOR ImageImport;
+            if (!ReadProcessMemory(hProcess, pImageImport, &ImageImport, sizeof(ImageImport), NULL)) {
+                DETOUR_TRACE(("ReadProcessMemory failed: %lu\n", GetLastError()));
+                goto finish;
+            }
+            inh.IMPORT_DIRECTORY.Size += sizeof(IMAGE_IMPORT_DESCRIPTOR);
+            if (!ImageImport.Name) {
+                break;
+            }
+            ++pImageImport;
+        } while (TRUE);
+
+        DWORD dwLastError = GetLastError();
+        OutputDebugString(TEXT("[This PE file has an import table, but the import table size is marked as 0. This is an error.")
+            TEXT("If it is not repaired, the launched program will not work properly, Detours has automatically repaired its import table size for you! ! !]\r\n"));
+        if (GetLastError() != dwLastError) {
+            SetLastError(dwLastError);
+        }
+    }
+
+    DETOUR_TRACE(("     Imports: %p..%p\n",
+                  pbModule + inh.IMPORT_DIRECTORY.VirtualAddress,
+                  pbModule + inh.IMPORT_DIRECTORY.VirtualAddress +
+                  inh.IMPORT_DIRECTORY.Size));
+
+    // Calculate new import directory size.  Note that since inh is from another
+    // process, inh could have been corrupted. We need to protect against
+    // integer overflow in allocation calculations.
+    DWORD nOldDlls = inh.IMPORT_DIRECTORY.Size / sizeof(IMAGE_IMPORT_DESCRIPTOR);
+    DWORD obRem;
+    if (DWordMult(sizeof(IMAGE_IMPORT_DESCRIPTOR), nDlls, &obRem) != S_OK) {
+        DETOUR_TRACE(("too many new DLLs.\n"));
+        goto finish;
+    }
+    DWORD obOld;
+    if (DWordAdd(obRem, sizeof(IMAGE_IMPORT_DESCRIPTOR) * nOldDlls, &obOld) != S_OK) {
+        DETOUR_TRACE(("DLL entries overflow.\n"));
+        goto finish;
+    }
+    DWORD obTab = PadToDwordPtr(obOld);
+    // Check for integer overflow.
+    if (obTab < obOld) {
+        DETOUR_TRACE(("DLL entries padding overflow.\n"));
+        goto finish;
+    }
+    DWORD stSize;
+    if (DWordMult(sizeof(DWORD_XX) * 4, nDlls, &stSize) != S_OK) {
+        DETOUR_TRACE(("String table overflow.\n"));
+        goto finish;
+    }
+    DWORD obDll;
+    if (DWordAdd(obTab, stSize, &obDll) != S_OK) {
+        DETOUR_TRACE(("Import table size overflow\n"));
+        goto finish;
+    }
+    DWORD obStr = obDll;
+    cbNew = obStr;
+    for (n = 0; n < nDlls; n++) {
+        if (DWordAdd(cbNew, PadToDword((DWORD)strlen(plpDlls[n]) + 1), &cbNew) != S_OK) {
+            DETOUR_TRACE(("Overflow adding string table entry\n"));
+            goto finish;
+        }
+    }
+    pbNew = new BYTE [cbNew];
+    if (pbNew == NULL) {
+        DETOUR_TRACE(("new BYTE [cbNew] failed.\n"));
+        goto finish;
+    }
+    ZeroMemory(pbNew, cbNew);
+
+    PBYTE pbBase = pbModule;
+    PBYTE pbNext = pbBase
+        + inh.OptionalHeader.BaseOfCode
+        + inh.OptionalHeader.SizeOfCode
+        + inh.OptionalHeader.SizeOfInitializedData
+        + inh.OptionalHeader.SizeOfUninitializedData;
+    if (pbBase < pbNext) {
+        pbBase = pbNext;
+    }
+    DETOUR_TRACE(("pbBase = %p\n", pbBase));
+
+    PBYTE pbNewIid = FindAndAllocateNearBase(hProcess, pbModule, pbBase, cbNew);
+    if (pbNewIid == NULL) {
+        DETOUR_TRACE(("FindAndAllocateNearBase failed.\n"));
+        goto finish;
+    }
+
+    PIMAGE_IMPORT_DESCRIPTOR piid = (PIMAGE_IMPORT_DESCRIPTOR)pbNew;
+    IMAGE_THUNK_DATAXX *pt = NULL;
+
+    DWORD obBase = (DWORD)(pbNewIid - pbModule);
+    DWORD dwProtect = 0;
+
+    if (inh.IMPORT_DIRECTORY.VirtualAddress != 0) {
+        // Read the old import directory if it exists.
+        DETOUR_TRACE(("IMPORT_DIRECTORY perms=%lx\n", dwProtect));
+
+        if (!ReadProcessMemory(hProcess,
+                               pbModule + inh.IMPORT_DIRECTORY.VirtualAddress,
+                               &piid[nDlls],
+                               nOldDlls * sizeof(IMAGE_IMPORT_DESCRIPTOR), &cbRead)
+            || cbRead < nOldDlls * sizeof(IMAGE_IMPORT_DESCRIPTOR)) {
+
+            DETOUR_TRACE(("ReadProcessMemory(imports) failed: %lu\n", GetLastError()));
+            goto finish;
+        }
+    }
+
+    for (n = 0; n < nDlls; n++) {
+        HRESULT hrRet = StringCchCopyA((char*)pbNew + obStr, cbNew - obStr, plpDlls[n]);
+        if (FAILED(hrRet)) {
+            DETOUR_TRACE(("StringCchCopyA failed: %08lx\n", hrRet));
+            goto finish;
+        }
+
+        // After copying the string, we patch up the size "??" bits if any.
+        hrRet = ReplaceOptionalSizeA((char*)pbNew + obStr,
+                                     cbNew - obStr,
+                                     DETOURS_STRINGIFY(DETOURS_BITS_XX));
+        if (FAILED(hrRet)) {
+            DETOUR_TRACE(("ReplaceOptionalSizeA failed: %08lx\n", hrRet));
+            goto finish;
+        }
+
+        DWORD nOffset = obTab + (sizeof(IMAGE_THUNK_DATAXX) * (4 * n));
+        piid[n].OriginalFirstThunk = obBase + nOffset;
+      
+        // We need 2 thunks for the import table and 2 thunks for the IAT.
+        // One for an ordinal import and one to mark the end of the list.
+        pt = ((IMAGE_THUNK_DATAXX*)(pbNew + nOffset));
+        pt[0].u1.Ordinal = IMAGE_ORDINAL_FLAG_XX + 1;
+        pt[1].u1.Ordinal = 0;
+
+        nOffset = obTab + (sizeof(IMAGE_THUNK_DATAXX) * ((4 * n) + 2));
+        piid[n].FirstThunk = obBase + nOffset;
+        pt = ((IMAGE_THUNK_DATAXX*)(pbNew + nOffset));
+        pt[0].u1.Ordinal = IMAGE_ORDINAL_FLAG_XX + 1;
+        pt[1].u1.Ordinal = 0;
+        piid[n].TimeDateStamp = 0;
+        piid[n].ForwarderChain = 0;
+        piid[n].Name = obBase + obStr;
+
+        obStr += PadToDword((DWORD)strlen(plpDlls[n]) + 1);
+    }
+    _Analysis_assume_(obStr <= cbNew);
+
+#if 0
+    for (i = 0; i < nDlls + nOldDlls; i++) {
+        DETOUR_TRACE(("%8d. Look=%08x Time=%08x Fore=%08x Name=%08x Addr=%08x\n",
+                      i,
+                      piid[i].OriginalFirstThunk,
+                      piid[i].TimeDateStamp,
+                      piid[i].ForwarderChain,
+                      piid[i].Name,
+                      piid[i].FirstThunk));
+        if (piid[i].OriginalFirstThunk == 0 && piid[i].FirstThunk == 0) {
+            break;
+        }
+    }
+#endif
+
+    if (!WriteProcessMemory(hProcess, pbNewIid, pbNew, obStr, NULL)) {
+        DETOUR_TRACE(("WriteProcessMemory(iid) failed: %lu\n", GetLastError()));
+        goto finish;
+    }
+
+    DETOUR_TRACE(("obBaseBef = %08lx..%08lx\n",
+                  inh.IMPORT_DIRECTORY.VirtualAddress,
+                  inh.IMPORT_DIRECTORY.VirtualAddress + inh.IMPORT_DIRECTORY.Size));
+    DETOUR_TRACE(("obBaseAft = %08lx..%08lx\n", obBase, obBase + obStr));
+
+    // In this case the file didn't have an import directory in first place,
+    // so we couldn't fix the missing IAT above. We still need to explicitly
+    // provide an IAT to prevent to loader from looking for one.
+    //
+    if (inh.IAT_DIRECTORY.VirtualAddress == 0) {
+        inh.IAT_DIRECTORY.VirtualAddress = obBase;
+        inh.IAT_DIRECTORY.Size = cbNew;
+    }
+
+    inh.IMPORT_DIRECTORY.VirtualAddress = obBase;
+    inh.IMPORT_DIRECTORY.Size = cbNew;
+
+    /////////////////////// Update the NT header for the new import directory.
+    //
+    if (!DetourVirtualProtectSameExecuteEx(hProcess, pbModule, inh.OptionalHeader.SizeOfHeaders,
+                                           PAGE_EXECUTE_READWRITE, &dwProtect)) {
+        DETOUR_TRACE(("VirtualProtectEx(inh) write failed: %lu\n", GetLastError()));
+        goto finish;
+    }
+
+    inh.OptionalHeader.CheckSum = 0;
+
+    if (!WriteProcessMemory(hProcess, pbModule, &idh, sizeof(idh), NULL)) {
+        DETOUR_TRACE(("WriteProcessMemory(idh) failed: %lu\n", GetLastError()));
+        goto finish;
+    }
+    DETOUR_TRACE(("WriteProcessMemory(idh:%p..%p)\n", pbModule, pbModule + sizeof(idh)));
+
+    if (!WriteProcessMemory(hProcess, pbModule + idh.e_lfanew, &inh, sizeof(inh), NULL)) {
+        DETOUR_TRACE(("WriteProcessMemory(inh) failed: %lu\n", GetLastError()));
+        goto finish;
+    }
+    DETOUR_TRACE(("WriteProcessMemory(inh:%p..%p)\n",
+                  pbModule + idh.e_lfanew,
+                  pbModule + idh.e_lfanew + sizeof(inh)));
+
+    if (!VirtualProtectEx(hProcess, pbModule, inh.OptionalHeader.SizeOfHeaders,
+                          dwProtect, &dwProtect)) {
+        DETOUR_TRACE(("VirtualProtectEx(idh) restore failed: %lu\n", GetLastError()));
+        goto finish;
+    }
+
+    fSucceeded = TRUE;
+    goto finish;
+}

--- a/cpp/src/wait_group.cpp
+++ b/cpp/src/wait_group.cpp
@@ -55,13 +55,7 @@ void wait_group::add(int n)
 	atomic_int64_set((ATOMIC*) state_, 0);
 
 	for (size_t i = 0; i < w; i++) {
-#ifdef	_DEBUG
-		unsigned long* tid = new unsigned long;
-		*tid = acl::thread::self();
-		box_->push(tid);
-#else
 		box_->push(NULL);
-#endif
 	}
 }
 
@@ -84,14 +78,8 @@ void wait_group::wait()
 		//等待者数量加一，失败的话重新获取state
 		if (atomic_int64_cas((ATOMIC*) state_, state, state + 1) == state) {
 			bool found;
-#ifdef	_DEBUG
-			unsigned long* tid = box_->pop(-1, &found);
-			assert(found);
-			delete tid;
-#else
 			(void) box_->pop(-1, &found);
 			assert(found);
-#endif
 			if(atomic_int64_fetch_add((ATOMIC*) state_, 0) == 0) {
 				return;
 			}

--- a/cpp/src/wait_group.cpp
+++ b/cpp/src/wait_group.cpp
@@ -1,0 +1,104 @@
+#include "stdafx.hpp"
+#include <assert.h>
+#include "../../c/src/common/atomic.h"
+#include "fiber/fiber_tbox.hpp"
+#include "fiber/wait_group.hpp"
+
+namespace acl {
+
+wait_group::wait_group()
+{
+	box_   = new acl::fiber_tbox<unsigned long>;
+	state_ = (void*) atomic_new();
+	n_     = 0;
+
+	atomic_set((ATOMIC*) state_, &n_);
+	atomic_int64_set((ATOMIC*) state_, n_);
+}
+
+wait_group::~wait_group()
+{
+	delete box_;
+	atomic_free((ATOMIC*) state_);
+}
+
+void wait_group::add(int n)
+{
+	long long state = atomic_int64_add_fetch((ATOMIC*) state_,
+			(long long) n << 32);
+
+	//高32位为任务数量
+	int c = (int)(state >> 32);
+
+	//低32位为等待者数量
+	unsigned w =  (unsigned) state;
+
+	//count不能小于0
+	if (c < 0){
+		msg_fatal("Negative wait_group counter");
+	}
+
+	if (w != 0 && n > 0 && c == n){
+		msg_fatal("Add called concurrently with wait");
+	}
+
+	if (c > 0 || w == 0) {
+		return;
+	}
+
+	//检查state是否被修改
+	if (atomic_int64_fetch_add((ATOMIC*) state_, 0) != state) {
+		msg_fatal("Add called concurrently with wait");
+	}
+
+	//这里count为0了，清空state并唤醒所有等待者
+	atomic_int64_set((ATOMIC*) state_, 0);
+
+	for (size_t i = 0; i < w; i++) {
+#ifdef	_DEBUG
+		unsigned long* tid = new unsigned long;
+		*tid = acl::thread::self();
+		box_->push(tid);
+#else
+		box_->push(NULL);
+#endif
+	}
+}
+
+void wait_group::done()
+{
+	add(-1);
+}
+
+void wait_group::wait()
+{
+	for(;;) {
+		long long state = atomic_int64_fetch_add((ATOMIC*) state_, 0);
+		int c = (int) (state >> 32);
+
+		//没有任务直接返回
+		if (c == 0) {
+			return;
+		}
+
+		//等待者数量加一，失败的话重新获取state
+		if (atomic_int64_cas((ATOMIC*) state_, state, state + 1) == state) {
+			bool found;
+#ifdef	_DEBUG
+			unsigned long* tid = box_->pop(-1, &found);
+			assert(found);
+			delete tid;
+#else
+			(void) box_->pop(-1, &found);
+			assert(found);
+#endif
+			if(atomic_int64_fetch_add((ATOMIC*) state_, 0) == 0) {
+				return;
+			}
+
+			msg_fatal("Reused before previous wait has returned");
+		}
+	}
+}
+
+} // namespace acl

--- a/cpp/src/winapi_hook.cpp
+++ b/cpp/src/winapi_hook.cpp
@@ -76,7 +76,6 @@ bool winapi_hook(void) {
 	if (pthread_once(&__once, winapi_hook_once) != 0) {
 		return false;
 	}
-	winapi_hook_once();
 
 #if 0
 	// just test socket hook

--- a/fiber.xcodeproj/project.pbxproj
+++ b/fiber.xcodeproj/project.pbxproj
@@ -7,44 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		703BA809254DB0E000C8F36E /* rfc1035.c in Sources */ = {isa = PBXBuildFile; fileRef = 703BA805254DB0E000C8F36E /* rfc1035.c */; };
-		703BA80A254DB0E000C8F36E /* resolver.c in Sources */ = {isa = PBXBuildFile; fileRef = 703BA806254DB0E000C8F36E /* resolver.c */; };
-		703BA80B254DB0E000C8F36E /* resolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 703BA807254DB0E000C8F36E /* resolver.h */; };
-		703BA80C254DB0E000C8F36E /* rfc1035.h in Headers */ = {isa = PBXBuildFile; fileRef = 703BA808254DB0E000C8F36E /* rfc1035.h */; };
-		70753928251E04A0005B6E56 /* iostuff.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753906251E049E005B6E56 /* iostuff.h */; };
-		70753929251E04A0005B6E56 /* fifo.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753907251E049E005B6E56 /* fifo.c */; };
-		7075392A251E04A0005B6E56 /* atomic.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753908251E049E005B6E56 /* atomic.c */; };
-		7075392B251E04A0005B6E56 /* msg.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753909251E049E005B6E56 /* msg.h */; };
-		7075392C251E04A0005B6E56 /* strops.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075390A251E049E005B6E56 /* strops.h */; };
-		7075392D251E04A0005B6E56 /* argv.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075390B251E049E005B6E56 /* argv.c */; };
-		7075392E251E04A0005B6E56 /* ring.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075390C251E049E005B6E56 /* ring.c */; };
-		7075392F251E04A0005B6E56 /* init.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075390D251E049F005B6E56 /* init.h */; };
-		70753930251E04A0005B6E56 /* pthread_patch.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075390E251E049F005B6E56 /* pthread_patch.c */; };
-		70753931251E04A0005B6E56 /* socketpair.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075390F251E049F005B6E56 /* socketpair.c */; };
-		70753932251E04A0005B6E56 /* atomic.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753910251E049F005B6E56 /* atomic.h */; };
-		70753933251E04A0005B6E56 /* ring.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753911251E049F005B6E56 /* ring.h */; };
-		70753934251E04A0005B6E56 /* close_on_exec.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753912251E049F005B6E56 /* close_on_exec.c */; };
-		70753935251E04A0005B6E56 /* non_blocking.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753913251E049F005B6E56 /* non_blocking.c */; };
-		70753936251E04A0005B6E56 /* doze.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753914251E049F005B6E56 /* doze.c */; };
-		70753937251E04A0005B6E56 /* fifo.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753915251E049F005B6E56 /* fifo.h */; };
-		70753938251E04A0005B6E56 /* sane_socket.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753916251E049F005B6E56 /* sane_socket.h */; };
-		70753939251E04A0005B6E56 /* gettimeofday.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753917251E049F005B6E56 /* gettimeofday.c */; };
-		7075393A251E04A0005B6E56 /* iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753918251E049F005B6E56 /* iterator.h */; };
-		7075393B251E04A0005B6E56 /* tcp_nodelay.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753919251E049F005B6E56 /* tcp_nodelay.c */; };
-		7075393C251E04A0005B6E56 /* htable.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075391A251E049F005B6E56 /* htable.c */; };
-		7075393D251E04A0005B6E56 /* gettimeofday.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075391B251E049F005B6E56 /* gettimeofday.h */; };
-		7075393E251E04A0005B6E56 /* msg.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075391C251E049F005B6E56 /* msg.c */; };
-		7075393F251E04A0005B6E56 /* init.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075391D251E049F005B6E56 /* init.c */; };
-		70753940251E04A0005B6E56 /* memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075391E251E049F005B6E56 /* memory.h */; };
-		70753941251E04A0005B6E56 /* pthread_patch.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075391F251E049F005B6E56 /* pthread_patch.h */; };
-		70753942251E04A0005B6E56 /* sane_socket.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753920251E049F005B6E56 /* sane_socket.c */; };
-		70753943251E04A0005B6E56 /* memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753921251E049F005B6E56 /* memory.c */; };
-		70753944251E04A0005B6E56 /* open_limit.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753922251E049F005B6E56 /* open_limit.c */; };
-		70753945251E04A0005B6E56 /* htable.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753923251E049F005B6E56 /* htable.h */; };
-		70753946251E04A0005B6E56 /* strops.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753924251E04A0005B6E56 /* strops.c */; };
-		70753947251E04A0005B6E56 /* array.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753925251E04A0005B6E56 /* array.h */; };
-		70753948251E04A0005B6E56 /* array.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753926251E04A0005B6E56 /* array.c */; };
-		70753949251E04A0005B6E56 /* argv.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753927251E04A0005B6E56 /* argv.h */; };
 		70753954251E0505005B6E56 /* fiber_base.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075394A251E0504005B6E56 /* fiber_base.h */; };
 		70753955251E0505005B6E56 /* libfiber.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075394B251E0504005B6E56 /* libfiber.h */; };
 		70753956251E0505005B6E56 /* fiber_hook.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075394C251E0504005B6E56 /* fiber_hook.h */; };
@@ -55,96 +17,124 @@
 		7075395B251E0505005B6E56 /* fiber_lock.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753951251E0505005B6E56 /* fiber_lock.h */; };
 		7075395C251E0505005B6E56 /* fiber_channel.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753952251E0505005B6E56 /* fiber_channel.h */; };
 		7075395D251E0505005B6E56 /* fiber_event.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753953251E0505005B6E56 /* fiber_event.h */; };
-		70753967251E0515005B6E56 /* hook.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075395E251E0514005B6E56 /* hook.h */; };
-		70753968251E0515005B6E56 /* getaddrinfo.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075395F251E0515005B6E56 /* getaddrinfo.c */; };
-		70753969251E0515005B6E56 /* epoll.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753960251E0515005B6E56 /* epoll.c */; };
-		7075396A251E0515005B6E56 /* gethostbyname.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753961251E0515005B6E56 /* gethostbyname.c */; };
-		7075396C251E0515005B6E56 /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753963251E0515005B6E56 /* io.c */; };
-		7075396D251E0515005B6E56 /* poll.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753964251E0515005B6E56 /* poll.c */; };
-		7075396E251E0515005B6E56 /* socket.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753965251E0515005B6E56 /* socket.c */; };
-		7075396F251E0515005B6E56 /* select.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753966251E0515005B6E56 /* select.c */; };
-		70753975251E0522005B6E56 /* exp_jmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753970251E0522005B6E56 /* exp_jmp.h */; };
-		70753976251E0522005B6E56 /* fiber_unix.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753971251E0522005B6E56 /* fiber_unix.c */; };
-		70753977251E0522005B6E56 /* unix_jmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753972251E0522005B6E56 /* unix_jmp.h */; };
-		70753978251E0522005B6E56 /* boost_jmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753973251E0522005B6E56 /* boost_jmp.h */; };
-		70753979251E0522005B6E56 /* fiber_win.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753974251E0522005B6E56 /* fiber_win.c */; };
-		70753986251E0533005B6E56 /* event_select.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075397A251E0532005B6E56 /* event_select.c */; };
-		70753987251E0533005B6E56 /* event_poll.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075397B251E0532005B6E56 /* event_poll.c */; };
-		70753988251E0533005B6E56 /* event_poll.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075397C251E0532005B6E56 /* event_poll.h */; };
-		70753989251E0533005B6E56 /* event_wmsg.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075397D251E0532005B6E56 /* event_wmsg.h */; };
-		7075398A251E0533005B6E56 /* event_epoll.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075397E251E0532005B6E56 /* event_epoll.h */; };
-		7075398B251E0533005B6E56 /* event_iocp.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075397F251E0532005B6E56 /* event_iocp.h */; };
-		7075398C251E0533005B6E56 /* event_epoll.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753980251E0532005B6E56 /* event_epoll.c */; };
-		7075398D251E0533005B6E56 /* event_kqueue.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753981251E0532005B6E56 /* event_kqueue.c */; };
-		7075398E251E0533005B6E56 /* event_kqueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753982251E0532005B6E56 /* event_kqueue.h */; };
-		7075398F251E0533005B6E56 /* event_wmsg.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753983251E0532005B6E56 /* event_wmsg.c */; };
-		70753990251E0533005B6E56 /* event_select.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753984251E0533005B6E56 /* event_select.h */; };
-		70753991251E0533005B6E56 /* event_iocp.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753985251E0533005B6E56 /* event_iocp.c */; };
-		70753998251E053F005B6E56 /* valid_hostname.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753992251E053E005B6E56 /* valid_hostname.h */; };
-		7075399A251E053F005B6E56 /* sane_inet.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753994251E053F005B6E56 /* sane_inet.c */; };
-		7075399C251E053F005B6E56 /* valid_hostname.c in Sources */ = {isa = PBXBuildFile; fileRef = 70753996251E053F005B6E56 /* valid_hostname.c */; };
-		7075399D251E053F005B6E56 /* sane_inet.h in Headers */ = {isa = PBXBuildFile; fileRef = 70753997251E053F005B6E56 /* sane_inet.h */; };
-		707539AE251E0568005B6E56 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 7075399E251E0567005B6E56 /* common.h */; };
-		707539AF251E0568005B6E56 /* file_event.c in Sources */ = {isa = PBXBuildFile; fileRef = 7075399F251E0567005B6E56 /* file_event.c */; };
-		707539B0251E0568005B6E56 /* fiber_sem.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539A0251E0567005B6E56 /* fiber_sem.c */; };
-		707539B1251E0568005B6E56 /* fiber_io.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539A1251E0567005B6E56 /* fiber_io.c */; };
-		707539B2251E0568005B6E56 /* fiber.h in Headers */ = {isa = PBXBuildFile; fileRef = 707539A2251E0567005B6E56 /* fiber.h */; };
-		707539B3251E0568005B6E56 /* channel.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539A3251E0567005B6E56 /* channel.c */; };
-		707539B4251E0568005B6E56 /* fiber_lock.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539A4251E0567005B6E56 /* fiber_lock.c */; };
-		707539B5251E0568005B6E56 /* fiber_cond.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539A5251E0568005B6E56 /* fiber_cond.c */; };
-		707539B6251E0568005B6E56 /* stdafx.h in Headers */ = {isa = PBXBuildFile; fileRef = 707539A6251E0568005B6E56 /* stdafx.h */; };
-		707539B7251E0568005B6E56 /* event.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539A7251E0568005B6E56 /* event.c */; };
-		707539B8251E0568005B6E56 /* event.h in Headers */ = {isa = PBXBuildFile; fileRef = 707539A8251E0568005B6E56 /* event.h */; };
-		707539B9251E0568005B6E56 /* fiber.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539A9251E0568005B6E56 /* fiber.c */; };
-		707539BA251E0568005B6E56 /* stdafx.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539AA251E0568005B6E56 /* stdafx.c */; };
-		707539BB251E0568005B6E56 /* fiber_event.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539AB251E0568005B6E56 /* fiber_event.c */; };
-		707539BC251E0568005B6E56 /* fbase_event.c in Sources */ = {isa = PBXBuildFile; fileRef = 707539AC251E0568005B6E56 /* fbase_event.c */; };
-		707539BD251E0568005B6E56 /* define.h in Headers */ = {isa = PBXBuildFile; fileRef = 707539AD251E0568005B6E56 /* define.h */; };
-		707539C0251E05DA005B6E56 /* jump_gas.S in Sources */ = {isa = PBXBuildFile; fileRef = 707539BE251E05DA005B6E56 /* jump_gas.S */; };
-		707539C1251E05DA005B6E56 /* make_gas.S in Sources */ = {isa = PBXBuildFile; fileRef = 707539BF251E05DA005B6E56 /* make_gas.S */; };
-		70E41F6126F32AF90068042B /* hook.c in Sources */ = {isa = PBXBuildFile; fileRef = 70E41F6026F32AF90068042B /* hook.c */; };
+		70D5A2142D155EDD00E75387 /* event_epoll.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1802D155EDD00E75387 /* event_epoll.c */; };
+		70D5A2182D155EDD00E75387 /* argv.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1442D155EDD00E75387 /* argv.c */; };
+		70D5A2192D155EDD00E75387 /* jump_gas.S in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1972D155EDD00E75387 /* jump_gas.S */; };
+		70D5A21B2D155EDD00E75387 /* pthread_patch.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1612D155EDD00E75387 /* pthread_patch.c */; };
+		70D5A21C2D155EDD00E75387 /* yqueue.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1722D155EDD00E75387 /* yqueue.c */; };
+		70D5A21D2D155EDD00E75387 /* gethostbyname.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1FC2D155EDD00E75387 /* gethostbyname.c */; };
+		70D5A21F2D155EDD00E75387 /* event.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A18E2D155EDD00E75387 /* event.c */; };
+		70D5A2212D155EDD00E75387 /* strops.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A16B2D155EDD00E75387 /* strops.c */; };
+		70D5A2222D155EDD00E75387 /* socket.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2032D155EDD00E75387 /* socket.c */; };
+		70D5A2252D155EDD00E75387 /* sync_waiter.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2122D155EDD00E75387 /* sync_waiter.c */; };
+		70D5A2262D155EDD00E75387 /* fiber_read.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1F82D155EDD00E75387 /* fiber_read.c */; };
+		70D5A2272D155EDD00E75387 /* rfc1035.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1782D155EDD00E75387 /* rfc1035.c */; };
+		70D5A2292D155EDD00E75387 /* avl.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A14A2D155EDD00E75387 /* avl.c */; };
+		70D5A22B2D155EDD00E75387 /* fcntl.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1F72D155EDD00E75387 /* fcntl.c */; };
+		70D5A22E2D155EDD00E75387 /* fiber_write.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1F92D155EDD00E75387 /* fiber_write.c */; };
+		70D5A2332D155EDD00E75387 /* hook.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1FE2D155EDD00E75387 /* hook.c */; };
+		70D5A2352D155EDD00E75387 /* sane_inet.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A17A2D155EDD00E75387 /* sane_inet.c */; };
+		70D5A2372D155EDD00E75387 /* sync_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2102D155EDD00E75387 /* sync_type.c */; };
+		70D5A2382D155EDD00E75387 /* resolver.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1762D155EDD00E75387 /* resolver.c */; };
+		70D5A2392D155EDD00E75387 /* stdafx.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2062D155EDD00E75387 /* stdafx.c */; };
+		70D5A23F2D155EDD00E75387 /* event_poll.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1882D155EDD00E75387 /* event_poll.c */; };
+		70D5A2412D155EDD00E75387 /* atomic.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1482D155EDD00E75387 /* atomic.c */; };
+		70D5A2432D155EDD00E75387 /* event_kqueue.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1862D155EDD00E75387 /* event_kqueue.c */; };
+		70D5A2462D155EDD00E75387 /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2002D155EDD00E75387 /* io.c */; };
+		70D5A2482D155EDD00E75387 /* fiber.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1F32D155EDD00E75387 /* fiber.c */; };
+		70D5A2492D155EDD00E75387 /* event_iocp.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1842D155EDD00E75387 /* event_iocp.c */; };
+		70D5A24B2D155EDD00E75387 /* doze.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A14D2D155EDD00E75387 /* doze.c */; };
+		70D5A24F2D155EDD00E75387 /* poll.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2012D155EDD00E75387 /* poll.c */; };
+		70D5A2552D155EDD00E75387 /* ypipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1702D155EDD00E75387 /* ypipe.c */; };
+		70D5A2592D155EDD00E75387 /* fiber_sem.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A20C2D155EDD00E75387 /* fiber_sem.c */; };
+		70D5A25D2D155EDD00E75387 /* ring.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1662D155EDD00E75387 /* ring.c */; };
+		70D5A25E2D155EDD00E75387 /* socketpair.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1692D155EDD00E75387 /* socketpair.c */; };
+		70D5A25F2D155EDD00E75387 /* getaddrinfo.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1FB2D155EDD00E75387 /* getaddrinfo.c */; };
+		70D5A2602D155EDD00E75387 /* fiber_io.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1F42D155EDD00E75387 /* fiber_io.c */; };
+		70D5A2612D155EDD00E75387 /* fiber_event.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2092D155EDD00E75387 /* fiber_event.c */; };
+		70D5A2622D155EDD00E75387 /* file_event.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1F52D155EDD00E75387 /* file_event.c */; };
+		70D5A2632D155EDD00E75387 /* select.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2022D155EDD00E75387 /* select.c */; };
+		70D5A2642D155EDD00E75387 /* event_io_uring.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1822D155EDD00E75387 /* event_io_uring.c */; };
+		70D5A2672D155EDD00E75387 /* gettimeofday.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1512D155EDD00E75387 /* gettimeofday.c */; };
+		70D5A2682D155EDD00E75387 /* htable.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1532D155EDD00E75387 /* htable.c */; };
+		70D5A2692D155EDD00E75387 /* queue.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1632D155EDD00E75387 /* queue.c */; };
+		70D5A26C2D155EDD00E75387 /* fifo.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A14F2D155EDD00E75387 /* fifo.c */; };
+		70D5A26E2D155EDD00E75387 /* init.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1552D155EDD00E75387 /* init.c */; };
+		70D5A2722D155EDD00E75387 /* mbox.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1592D155EDD00E75387 /* mbox.c */; };
+		70D5A2742D155EDD00E75387 /* fiber_lock.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A20A2D155EDD00E75387 /* fiber_lock.c */; };
+		70D5A2752D155EDD00E75387 /* open_limit.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A15F2D155EDD00E75387 /* open_limit.c */; };
+		70D5A2772D155EDD00E75387 /* channel.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2072D155EDD00E75387 /* channel.c */; };
+		70D5A2782D155EDD00E75387 /* event_wmsg.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A18C2D155EDD00E75387 /* event_wmsg.c */; };
+		70D5A2792D155EDD00E75387 /* close_on_exec.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A14C2D155EDD00E75387 /* close_on_exec.c */; };
+		70D5A27B2D155EDD00E75387 /* tcp_nodelay.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A16C2D155EDD00E75387 /* tcp_nodelay.c */; };
+		70D5A27D2D155EDD00E75387 /* fiber_mutex.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A20B2D155EDD00E75387 /* fiber_mutex.c */; };
+		70D5A27E2D155EDD00E75387 /* memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A15B2D155EDD00E75387 /* memory.c */; };
+		70D5A2812D155EDD00E75387 /* read_wait.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1642D155EDD00E75387 /* read_wait.c */; };
+		70D5A2822D155EDD00E75387 /* make_gas.S in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1B22D155EDD00E75387 /* make_gas.S */; };
+		70D5A2832D155EDD00E75387 /* non_blocking.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A15E2D155EDD00E75387 /* non_blocking.c */; };
+		70D5A2862D155EDD00E75387 /* timer_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A16E2D155EDD00E75387 /* timer_cache.c */; };
+		70D5A2872D155EDD00E75387 /* epoll.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1F62D155EDD00E75387 /* epoll.c */; };
+		70D5A28B2D155EDD00E75387 /* file.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1FA2D155EDD00E75387 /* file.c */; };
+		70D5A28F2D155EDD00E75387 /* event_select.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A18A2D155EDD00E75387 /* event_select.c */; };
+		70D5A2912D155EDD00E75387 /* fiber_unix.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1EF2D155EDD00E75387 /* fiber_unix.c */; };
+		70D5A2952D155EDD00E75387 /* valid_hostname.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A17C2D155EDD00E75387 /* valid_hostname.c */; };
+		70D5A29B2D155EDD00E75387 /* sync_timer.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A20E2D155EDD00E75387 /* sync_timer.c */; };
+		70D5A29C2D155EDD00E75387 /* array.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1462D155EDD00E75387 /* array.c */; };
+		70D5A29D2D155EDD00E75387 /* fiber_win.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1F02D155EDD00E75387 /* fiber_win.c */; };
+		70D5A29E2D155EDD00E75387 /* msg.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A15D2D155EDD00E75387 /* msg.c */; };
+		70D5A2A32D155EDD00E75387 /* fiber_cond.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2082D155EDD00E75387 /* fiber_cond.c */; };
+		70D5A2A52D155EDD00E75387 /* fbase_event.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A18F2D155EDD00E75387 /* fbase_event.c */; };
+		70D5A2AE2D155EDD00E75387 /* sane_socket.c in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A1682D155EDD00E75387 /* sane_socket.c */; };
+		70D5A2B02D155EDD00E75387 /* memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A15A2D155EDD00E75387 /* memory.h */; };
+		70D5A2B12D155EDD00E75387 /* ring.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1652D155EDD00E75387 /* ring.h */; };
+		70D5A2B22D155EDD00E75387 /* mbox.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1582D155EDD00E75387 /* mbox.h */; };
+		70D5A2B32D155EDD00E75387 /* fifo.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A14E2D155EDD00E75387 /* fifo.h */; };
+		70D5A2B42D155EDD00E75387 /* argv.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1432D155EDD00E75387 /* argv.h */; };
+		70D5A2B52D155EDD00E75387 /* valid_hostname.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A17B2D155EDD00E75387 /* valid_hostname.h */; };
+		70D5A2B62D155EDD00E75387 /* init.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1542D155EDD00E75387 /* init.h */; };
+		70D5A2B72D155EDD00E75387 /* sync_timer.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A20D2D155EDD00E75387 /* sync_timer.h */; };
+		70D5A2B82D155EDD00E75387 /* fiber.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1902D155EDD00E75387 /* fiber.h */; };
+		70D5A2B92D155EDD00E75387 /* pthread_patch.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1602D155EDD00E75387 /* pthread_patch.h */; };
+		70D5A2BA2D155EDD00E75387 /* x86_jmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1F12D155EDD00E75387 /* x86_jmp.h */; };
+		70D5A2BB2D155EDD00E75387 /* event_kqueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1852D155EDD00E75387 /* event_kqueue.h */; };
+		70D5A2BC2D155EDD00E75387 /* ypipe.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A16F2D155EDD00E75387 /* ypipe.h */; };
+		70D5A2BD2D155EDD00E75387 /* array.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1452D155EDD00E75387 /* array.h */; };
+		70D5A2BE2D155EDD00E75387 /* iostuff.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1562D155EDD00E75387 /* iostuff.h */; };
+		70D5A2BF2D155EDD00E75387 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1422D155EDD00E75387 /* common.h */; };
+		70D5A2C02D155EDD00E75387 /* htable.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1522D155EDD00E75387 /* htable.h */; };
+		70D5A2C12D155EDD00E75387 /* sane_inet.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1792D155EDD00E75387 /* sane_inet.h */; };
+		70D5A2C22D155EDD00E75387 /* msg.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A15C2D155EDD00E75387 /* msg.h */; };
+		70D5A2C32D155EDD00E75387 /* sane_socket.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1672D155EDD00E75387 /* sane_socket.h */; };
+		70D5A2C42D155EDD00E75387 /* yqueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1712D155EDD00E75387 /* yqueue.h */; };
+		70D5A2C52D155EDD00E75387 /* event_poll.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1872D155EDD00E75387 /* event_poll.h */; };
+		70D5A2C62D155EDD00E75387 /* stdafx.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A2052D155EDD00E75387 /* stdafx.h */; };
+		70D5A2C72D155EDD00E75387 /* strops.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A16A2D155EDD00E75387 /* strops.h */; };
+		70D5A2C82D155EDD00E75387 /* event.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A17E2D155EDD00E75387 /* event.h */; };
+		70D5A2C92D155EDD00E75387 /* boost_jmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1ED2D155EDD00E75387 /* boost_jmp.h */; };
+		70D5A2CA2D155EDD00E75387 /* event_wmsg.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A18B2D155EDD00E75387 /* event_wmsg.h */; };
+		70D5A2CB2D155EDD00E75387 /* atomic.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1472D155EDD00E75387 /* atomic.h */; };
+		70D5A2CC2D155EDD00E75387 /* define.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1742D155EDD00E75387 /* define.h */; };
+		70D5A2CD2D155EDD00E75387 /* timer_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A16D2D155EDD00E75387 /* timer_cache.h */; };
+		70D5A2CE2D155EDD00E75387 /* hook.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1FD2D155EDD00E75387 /* hook.h */; };
+		70D5A2CF2D155EDD00E75387 /* event_io_uring.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1812D155EDD00E75387 /* event_io_uring.h */; };
+		70D5A2D02D155EDD00E75387 /* iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1572D155EDD00E75387 /* iterator.h */; };
+		70D5A2D12D155EDD00E75387 /* exp_jmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1EE2D155EDD00E75387 /* exp_jmp.h */; };
+		70D5A2D22D155EDD00E75387 /* event_epoll.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A17F2D155EDD00E75387 /* event_epoll.h */; };
+		70D5A2D32D155EDD00E75387 /* gettimeofday.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1502D155EDD00E75387 /* gettimeofday.h */; };
+		70D5A2D42D155EDD00E75387 /* avl.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1492D155EDD00E75387 /* avl.h */; };
+		70D5A2D52D155EDD00E75387 /* queue.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1622D155EDD00E75387 /* queue.h */; };
+		70D5A2D62D155EDD00E75387 /* avl_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A14B2D155EDD00E75387 /* avl_impl.h */; };
+		70D5A2D72D155EDD00E75387 /* sync_type.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A20F2D155EDD00E75387 /* sync_type.h */; };
+		70D5A2D82D155EDD00E75387 /* io.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1FF2D155EDD00E75387 /* io.h */; };
+		70D5A2D92D155EDD00E75387 /* event_select.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1892D155EDD00E75387 /* event_select.h */; };
+		70D5A2DA2D155EDD00E75387 /* resolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1752D155EDD00E75387 /* resolver.h */; };
+		70D5A2DB2D155EDD00E75387 /* event_iocp.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1832D155EDD00E75387 /* event_iocp.h */; };
+		70D5A2DC2D155EDD00E75387 /* sync_waiter.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A2112D155EDD00E75387 /* sync_waiter.h */; };
+		70D5A2DD2D155EDD00E75387 /* rfc1035.h in Headers */ = {isa = PBXBuildFile; fileRef = 70D5A1772D155EDD00E75387 /* rfc1035.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		070F35202090217900672EDC /* libfiber.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libfiber.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		703BA805254DB0E000C8F36E /* rfc1035.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rfc1035.c; path = c/src/dns/rfc1035.c; sourceTree = SOURCE_ROOT; };
-		703BA806254DB0E000C8F36E /* resolver.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resolver.c; path = c/src/dns/resolver.c; sourceTree = SOURCE_ROOT; };
-		703BA807254DB0E000C8F36E /* resolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = resolver.h; path = c/src/dns/resolver.h; sourceTree = SOURCE_ROOT; };
-		703BA808254DB0E000C8F36E /* rfc1035.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rfc1035.h; path = c/src/dns/rfc1035.h; sourceTree = SOURCE_ROOT; };
-		70753906251E049E005B6E56 /* iostuff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = iostuff.h; path = c/src/common/iostuff.h; sourceTree = SOURCE_ROOT; };
-		70753907251E049E005B6E56 /* fifo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fifo.c; path = c/src/common/fifo.c; sourceTree = SOURCE_ROOT; };
-		70753908251E049E005B6E56 /* atomic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = atomic.c; path = c/src/common/atomic.c; sourceTree = SOURCE_ROOT; };
-		70753909251E049E005B6E56 /* msg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = msg.h; path = c/src/common/msg.h; sourceTree = SOURCE_ROOT; };
-		7075390A251E049E005B6E56 /* strops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = strops.h; path = c/src/common/strops.h; sourceTree = SOURCE_ROOT; };
-		7075390B251E049E005B6E56 /* argv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = argv.c; path = c/src/common/argv.c; sourceTree = SOURCE_ROOT; };
-		7075390C251E049E005B6E56 /* ring.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ring.c; path = c/src/common/ring.c; sourceTree = SOURCE_ROOT; };
-		7075390D251E049F005B6E56 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = init.h; path = c/src/common/init.h; sourceTree = SOURCE_ROOT; };
-		7075390E251E049F005B6E56 /* pthread_patch.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pthread_patch.c; path = c/src/common/pthread_patch.c; sourceTree = SOURCE_ROOT; };
-		7075390F251E049F005B6E56 /* socketpair.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = socketpair.c; path = c/src/common/socketpair.c; sourceTree = SOURCE_ROOT; };
-		70753910251E049F005B6E56 /* atomic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = atomic.h; path = c/src/common/atomic.h; sourceTree = SOURCE_ROOT; };
-		70753911251E049F005B6E56 /* ring.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ring.h; path = c/src/common/ring.h; sourceTree = SOURCE_ROOT; };
-		70753912251E049F005B6E56 /* close_on_exec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = close_on_exec.c; path = c/src/common/close_on_exec.c; sourceTree = SOURCE_ROOT; };
-		70753913251E049F005B6E56 /* non_blocking.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = non_blocking.c; path = c/src/common/non_blocking.c; sourceTree = SOURCE_ROOT; };
-		70753914251E049F005B6E56 /* doze.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = doze.c; path = c/src/common/doze.c; sourceTree = SOURCE_ROOT; };
-		70753915251E049F005B6E56 /* fifo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fifo.h; path = c/src/common/fifo.h; sourceTree = SOURCE_ROOT; };
-		70753916251E049F005B6E56 /* sane_socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sane_socket.h; path = c/src/common/sane_socket.h; sourceTree = SOURCE_ROOT; };
-		70753917251E049F005B6E56 /* gettimeofday.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = gettimeofday.c; path = c/src/common/gettimeofday.c; sourceTree = SOURCE_ROOT; };
-		70753918251E049F005B6E56 /* iterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = iterator.h; path = c/src/common/iterator.h; sourceTree = SOURCE_ROOT; };
-		70753919251E049F005B6E56 /* tcp_nodelay.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tcp_nodelay.c; path = c/src/common/tcp_nodelay.c; sourceTree = SOURCE_ROOT; };
-		7075391A251E049F005B6E56 /* htable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = htable.c; path = c/src/common/htable.c; sourceTree = SOURCE_ROOT; };
-		7075391B251E049F005B6E56 /* gettimeofday.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gettimeofday.h; path = c/src/common/gettimeofday.h; sourceTree = SOURCE_ROOT; };
-		7075391C251E049F005B6E56 /* msg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = msg.c; path = c/src/common/msg.c; sourceTree = SOURCE_ROOT; };
-		7075391D251E049F005B6E56 /* init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = init.c; path = c/src/common/init.c; sourceTree = SOURCE_ROOT; };
-		7075391E251E049F005B6E56 /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = memory.h; path = c/src/common/memory.h; sourceTree = SOURCE_ROOT; };
-		7075391F251E049F005B6E56 /* pthread_patch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pthread_patch.h; path = c/src/common/pthread_patch.h; sourceTree = SOURCE_ROOT; };
-		70753920251E049F005B6E56 /* sane_socket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sane_socket.c; path = c/src/common/sane_socket.c; sourceTree = SOURCE_ROOT; };
-		70753921251E049F005B6E56 /* memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = memory.c; path = c/src/common/memory.c; sourceTree = SOURCE_ROOT; };
-		70753922251E049F005B6E56 /* open_limit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = open_limit.c; path = c/src/common/open_limit.c; sourceTree = SOURCE_ROOT; };
-		70753923251E049F005B6E56 /* htable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = htable.h; path = c/src/common/htable.h; sourceTree = SOURCE_ROOT; };
-		70753924251E04A0005B6E56 /* strops.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = strops.c; path = c/src/common/strops.c; sourceTree = SOURCE_ROOT; };
-		70753925251E04A0005B6E56 /* array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = array.h; path = c/src/common/array.h; sourceTree = SOURCE_ROOT; };
-		70753926251E04A0005B6E56 /* array.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = array.c; path = c/src/common/array.c; sourceTree = SOURCE_ROOT; };
-		70753927251E04A0005B6E56 /* argv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = argv.h; path = c/src/common/argv.h; sourceTree = SOURCE_ROOT; };
 		7075394A251E0504005B6E56 /* fiber_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fiber_base.h; path = c/include/fiber/fiber_base.h; sourceTree = "<group>"; };
 		7075394B251E0504005B6E56 /* libfiber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = libfiber.h; path = c/include/fiber/libfiber.h; sourceTree = "<group>"; };
 		7075394C251E0504005B6E56 /* fiber_hook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fiber_hook.h; path = c/include/fiber/fiber_hook.h; sourceTree = "<group>"; };
@@ -155,54 +145,120 @@
 		70753951251E0505005B6E56 /* fiber_lock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fiber_lock.h; path = c/include/fiber/fiber_lock.h; sourceTree = "<group>"; };
 		70753952251E0505005B6E56 /* fiber_channel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fiber_channel.h; path = c/include/fiber/fiber_channel.h; sourceTree = "<group>"; };
 		70753953251E0505005B6E56 /* fiber_event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fiber_event.h; path = c/include/fiber/fiber_event.h; sourceTree = "<group>"; };
-		7075395E251E0514005B6E56 /* hook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hook.h; path = c/src/hook/hook.h; sourceTree = SOURCE_ROOT; };
-		7075395F251E0515005B6E56 /* getaddrinfo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = getaddrinfo.c; path = c/src/hook/getaddrinfo.c; sourceTree = SOURCE_ROOT; };
-		70753960251E0515005B6E56 /* epoll.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = epoll.c; path = c/src/hook/epoll.c; sourceTree = SOURCE_ROOT; };
-		70753961251E0515005B6E56 /* gethostbyname.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = gethostbyname.c; path = c/src/hook/gethostbyname.c; sourceTree = SOURCE_ROOT; };
-		70753963251E0515005B6E56 /* io.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = io.c; path = c/src/hook/io.c; sourceTree = SOURCE_ROOT; };
-		70753964251E0515005B6E56 /* poll.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = poll.c; path = c/src/hook/poll.c; sourceTree = SOURCE_ROOT; };
-		70753965251E0515005B6E56 /* socket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = socket.c; path = c/src/hook/socket.c; sourceTree = SOURCE_ROOT; };
-		70753966251E0515005B6E56 /* select.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = select.c; path = c/src/hook/select.c; sourceTree = SOURCE_ROOT; };
-		70753970251E0522005B6E56 /* exp_jmp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = exp_jmp.h; path = c/src/fiber/exp_jmp.h; sourceTree = SOURCE_ROOT; };
-		70753971251E0522005B6E56 /* fiber_unix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fiber_unix.c; path = c/src/fiber/fiber_unix.c; sourceTree = SOURCE_ROOT; };
-		70753972251E0522005B6E56 /* unix_jmp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = unix_jmp.h; path = c/src/fiber/unix_jmp.h; sourceTree = SOURCE_ROOT; };
-		70753973251E0522005B6E56 /* boost_jmp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = boost_jmp.h; path = c/src/fiber/boost_jmp.h; sourceTree = SOURCE_ROOT; };
-		70753974251E0522005B6E56 /* fiber_win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fiber_win.c; path = c/src/fiber/fiber_win.c; sourceTree = SOURCE_ROOT; };
-		7075397A251E0532005B6E56 /* event_select.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = event_select.c; path = c/src/event/event_select.c; sourceTree = SOURCE_ROOT; };
-		7075397B251E0532005B6E56 /* event_poll.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = event_poll.c; path = c/src/event/event_poll.c; sourceTree = SOURCE_ROOT; };
-		7075397C251E0532005B6E56 /* event_poll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_poll.h; path = c/src/event/event_poll.h; sourceTree = SOURCE_ROOT; };
-		7075397D251E0532005B6E56 /* event_wmsg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_wmsg.h; path = c/src/event/event_wmsg.h; sourceTree = SOURCE_ROOT; };
-		7075397E251E0532005B6E56 /* event_epoll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_epoll.h; path = c/src/event/event_epoll.h; sourceTree = SOURCE_ROOT; };
-		7075397F251E0532005B6E56 /* event_iocp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_iocp.h; path = c/src/event/event_iocp.h; sourceTree = SOURCE_ROOT; };
-		70753980251E0532005B6E56 /* event_epoll.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = event_epoll.c; path = c/src/event/event_epoll.c; sourceTree = SOURCE_ROOT; };
-		70753981251E0532005B6E56 /* event_kqueue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = event_kqueue.c; path = c/src/event/event_kqueue.c; sourceTree = SOURCE_ROOT; };
-		70753982251E0532005B6E56 /* event_kqueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_kqueue.h; path = c/src/event/event_kqueue.h; sourceTree = SOURCE_ROOT; };
-		70753983251E0532005B6E56 /* event_wmsg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = event_wmsg.c; path = c/src/event/event_wmsg.c; sourceTree = SOURCE_ROOT; };
-		70753984251E0533005B6E56 /* event_select.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_select.h; path = c/src/event/event_select.h; sourceTree = SOURCE_ROOT; };
-		70753985251E0533005B6E56 /* event_iocp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = event_iocp.c; path = c/src/event/event_iocp.c; sourceTree = SOURCE_ROOT; };
-		70753992251E053E005B6E56 /* valid_hostname.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = valid_hostname.h; path = c/src/dns/valid_hostname.h; sourceTree = SOURCE_ROOT; };
-		70753994251E053F005B6E56 /* sane_inet.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sane_inet.c; path = c/src/dns/sane_inet.c; sourceTree = SOURCE_ROOT; };
-		70753996251E053F005B6E56 /* valid_hostname.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = valid_hostname.c; path = c/src/dns/valid_hostname.c; sourceTree = SOURCE_ROOT; };
-		70753997251E053F005B6E56 /* sane_inet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sane_inet.h; path = c/src/dns/sane_inet.h; sourceTree = SOURCE_ROOT; };
-		7075399E251E0567005B6E56 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = common.h; path = c/src/common.h; sourceTree = "<group>"; };
-		7075399F251E0567005B6E56 /* file_event.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = file_event.c; path = c/src/file_event.c; sourceTree = "<group>"; };
-		707539A0251E0567005B6E56 /* fiber_sem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fiber_sem.c; path = c/src/fiber_sem.c; sourceTree = "<group>"; };
-		707539A1251E0567005B6E56 /* fiber_io.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fiber_io.c; path = c/src/fiber_io.c; sourceTree = "<group>"; };
-		707539A2251E0567005B6E56 /* fiber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fiber.h; path = c/src/fiber.h; sourceTree = "<group>"; };
-		707539A3251E0567005B6E56 /* channel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = channel.c; path = c/src/channel.c; sourceTree = "<group>"; };
-		707539A4251E0567005B6E56 /* fiber_lock.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fiber_lock.c; path = c/src/fiber_lock.c; sourceTree = "<group>"; };
-		707539A5251E0568005B6E56 /* fiber_cond.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fiber_cond.c; path = c/src/fiber_cond.c; sourceTree = "<group>"; };
-		707539A6251E0568005B6E56 /* stdafx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stdafx.h; path = c/src/stdafx.h; sourceTree = "<group>"; };
-		707539A7251E0568005B6E56 /* event.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = event.c; path = c/src/event.c; sourceTree = "<group>"; };
-		707539A8251E0568005B6E56 /* event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event.h; path = c/src/event.h; sourceTree = "<group>"; };
-		707539A9251E0568005B6E56 /* fiber.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fiber.c; path = c/src/fiber.c; sourceTree = "<group>"; };
-		707539AA251E0568005B6E56 /* stdafx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = stdafx.c; path = c/src/stdafx.c; sourceTree = "<group>"; };
-		707539AB251E0568005B6E56 /* fiber_event.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fiber_event.c; path = c/src/fiber_event.c; sourceTree = "<group>"; };
-		707539AC251E0568005B6E56 /* fbase_event.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fbase_event.c; path = c/src/fbase_event.c; sourceTree = "<group>"; };
-		707539AD251E0568005B6E56 /* define.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = define.h; path = c/src/define.h; sourceTree = "<group>"; };
-		707539BE251E05DA005B6E56 /* jump_gas.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; name = jump_gas.S; path = c/src/fiber/boost/jump_gas.S; sourceTree = SOURCE_ROOT; };
-		707539BF251E05DA005B6E56 /* make_gas.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; name = make_gas.S; path = c/src/fiber/boost/make_gas.S; sourceTree = SOURCE_ROOT; };
-		70E41F6026F32AF90068042B /* hook.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = hook.c; path = c/src/hook/hook.c; sourceTree = SOURCE_ROOT; };
+		70D5A1422D155EDD00E75387 /* common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common.h; path = c/src/common.h; sourceTree = "<group>"; };
+		70D5A1432D155EDD00E75387 /* argv.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = argv.h; sourceTree = "<group>"; };
+		70D5A1442D155EDD00E75387 /* argv.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = argv.c; sourceTree = "<group>"; };
+		70D5A1452D155EDD00E75387 /* array.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = array.h; sourceTree = "<group>"; };
+		70D5A1462D155EDD00E75387 /* array.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = array.c; sourceTree = "<group>"; };
+		70D5A1472D155EDD00E75387 /* atomic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = atomic.h; sourceTree = "<group>"; };
+		70D5A1482D155EDD00E75387 /* atomic.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = atomic.c; sourceTree = "<group>"; };
+		70D5A1492D155EDD00E75387 /* avl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = avl.h; sourceTree = "<group>"; };
+		70D5A14A2D155EDD00E75387 /* avl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = avl.c; sourceTree = "<group>"; };
+		70D5A14B2D155EDD00E75387 /* avl_impl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = avl_impl.h; sourceTree = "<group>"; };
+		70D5A14C2D155EDD00E75387 /* close_on_exec.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = close_on_exec.c; sourceTree = "<group>"; };
+		70D5A14D2D155EDD00E75387 /* doze.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = doze.c; sourceTree = "<group>"; };
+		70D5A14E2D155EDD00E75387 /* fifo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fifo.h; sourceTree = "<group>"; };
+		70D5A14F2D155EDD00E75387 /* fifo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fifo.c; sourceTree = "<group>"; };
+		70D5A1502D155EDD00E75387 /* gettimeofday.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = gettimeofday.h; sourceTree = "<group>"; };
+		70D5A1512D155EDD00E75387 /* gettimeofday.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gettimeofday.c; sourceTree = "<group>"; };
+		70D5A1522D155EDD00E75387 /* htable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = htable.h; sourceTree = "<group>"; };
+		70D5A1532D155EDD00E75387 /* htable.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = htable.c; sourceTree = "<group>"; };
+		70D5A1542D155EDD00E75387 /* init.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		70D5A1552D155EDD00E75387 /* init.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = init.c; sourceTree = "<group>"; };
+		70D5A1562D155EDD00E75387 /* iostuff.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iostuff.h; sourceTree = "<group>"; };
+		70D5A1572D155EDD00E75387 /* iterator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iterator.h; sourceTree = "<group>"; };
+		70D5A1582D155EDD00E75387 /* mbox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mbox.h; sourceTree = "<group>"; };
+		70D5A1592D155EDD00E75387 /* mbox.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mbox.c; sourceTree = "<group>"; };
+		70D5A15A2D155EDD00E75387 /* memory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
+		70D5A15B2D155EDD00E75387 /* memory.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = memory.c; sourceTree = "<group>"; };
+		70D5A15C2D155EDD00E75387 /* msg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg.h; sourceTree = "<group>"; };
+		70D5A15D2D155EDD00E75387 /* msg.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg.c; sourceTree = "<group>"; };
+		70D5A15E2D155EDD00E75387 /* non_blocking.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = non_blocking.c; sourceTree = "<group>"; };
+		70D5A15F2D155EDD00E75387 /* open_limit.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = open_limit.c; sourceTree = "<group>"; };
+		70D5A1602D155EDD00E75387 /* pthread_patch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pthread_patch.h; sourceTree = "<group>"; };
+		70D5A1612D155EDD00E75387 /* pthread_patch.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pthread_patch.c; sourceTree = "<group>"; };
+		70D5A1622D155EDD00E75387 /* queue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = queue.h; sourceTree = "<group>"; };
+		70D5A1632D155EDD00E75387 /* queue.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = queue.c; sourceTree = "<group>"; };
+		70D5A1642D155EDD00E75387 /* read_wait.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = read_wait.c; sourceTree = "<group>"; };
+		70D5A1652D155EDD00E75387 /* ring.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ring.h; sourceTree = "<group>"; };
+		70D5A1662D155EDD00E75387 /* ring.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ring.c; sourceTree = "<group>"; };
+		70D5A1672D155EDD00E75387 /* sane_socket.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sane_socket.h; sourceTree = "<group>"; };
+		70D5A1682D155EDD00E75387 /* sane_socket.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sane_socket.c; sourceTree = "<group>"; };
+		70D5A1692D155EDD00E75387 /* socketpair.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = socketpair.c; sourceTree = "<group>"; };
+		70D5A16A2D155EDD00E75387 /* strops.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = strops.h; sourceTree = "<group>"; };
+		70D5A16B2D155EDD00E75387 /* strops.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = strops.c; sourceTree = "<group>"; };
+		70D5A16C2D155EDD00E75387 /* tcp_nodelay.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = tcp_nodelay.c; sourceTree = "<group>"; };
+		70D5A16D2D155EDD00E75387 /* timer_cache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = timer_cache.h; sourceTree = "<group>"; };
+		70D5A16E2D155EDD00E75387 /* timer_cache.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = timer_cache.c; sourceTree = "<group>"; };
+		70D5A16F2D155EDD00E75387 /* ypipe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ypipe.h; sourceTree = "<group>"; };
+		70D5A1702D155EDD00E75387 /* ypipe.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ypipe.c; sourceTree = "<group>"; };
+		70D5A1712D155EDD00E75387 /* yqueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = yqueue.h; sourceTree = "<group>"; };
+		70D5A1722D155EDD00E75387 /* yqueue.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = yqueue.c; sourceTree = "<group>"; };
+		70D5A1742D155EDD00E75387 /* define.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = define.h; path = c/src/define.h; sourceTree = "<group>"; };
+		70D5A1752D155EDD00E75387 /* resolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = resolver.h; sourceTree = "<group>"; };
+		70D5A1762D155EDD00E75387 /* resolver.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = resolver.c; sourceTree = "<group>"; };
+		70D5A1772D155EDD00E75387 /* rfc1035.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rfc1035.h; sourceTree = "<group>"; };
+		70D5A1782D155EDD00E75387 /* rfc1035.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rfc1035.c; sourceTree = "<group>"; };
+		70D5A1792D155EDD00E75387 /* sane_inet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sane_inet.h; sourceTree = "<group>"; };
+		70D5A17A2D155EDD00E75387 /* sane_inet.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sane_inet.c; sourceTree = "<group>"; };
+		70D5A17B2D155EDD00E75387 /* valid_hostname.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = valid_hostname.h; sourceTree = "<group>"; };
+		70D5A17C2D155EDD00E75387 /* valid_hostname.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = valid_hostname.c; sourceTree = "<group>"; };
+		70D5A17E2D155EDD00E75387 /* event.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = event.h; path = c/src/event.h; sourceTree = "<group>"; };
+		70D5A17F2D155EDD00E75387 /* event_epoll.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = event_epoll.h; sourceTree = "<group>"; };
+		70D5A1802D155EDD00E75387 /* event_epoll.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = event_epoll.c; sourceTree = "<group>"; };
+		70D5A1812D155EDD00E75387 /* event_io_uring.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = event_io_uring.h; sourceTree = "<group>"; };
+		70D5A1822D155EDD00E75387 /* event_io_uring.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = event_io_uring.c; sourceTree = "<group>"; };
+		70D5A1832D155EDD00E75387 /* event_iocp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = event_iocp.h; sourceTree = "<group>"; };
+		70D5A1842D155EDD00E75387 /* event_iocp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = event_iocp.c; sourceTree = "<group>"; };
+		70D5A1852D155EDD00E75387 /* event_kqueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = event_kqueue.h; sourceTree = "<group>"; };
+		70D5A1862D155EDD00E75387 /* event_kqueue.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = event_kqueue.c; sourceTree = "<group>"; };
+		70D5A1872D155EDD00E75387 /* event_poll.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = event_poll.h; sourceTree = "<group>"; };
+		70D5A1882D155EDD00E75387 /* event_poll.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = event_poll.c; sourceTree = "<group>"; };
+		70D5A1892D155EDD00E75387 /* event_select.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = event_select.h; sourceTree = "<group>"; };
+		70D5A18A2D155EDD00E75387 /* event_select.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = event_select.c; sourceTree = "<group>"; };
+		70D5A18B2D155EDD00E75387 /* event_wmsg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = event_wmsg.h; sourceTree = "<group>"; };
+		70D5A18C2D155EDD00E75387 /* event_wmsg.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = event_wmsg.c; sourceTree = "<group>"; };
+		70D5A18E2D155EDD00E75387 /* event.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = event.c; path = c/src/event.c; sourceTree = "<group>"; };
+		70D5A18F2D155EDD00E75387 /* fbase_event.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = fbase_event.c; path = c/src/fbase_event.c; sourceTree = "<group>"; };
+		70D5A1902D155EDD00E75387 /* fiber.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fiber.h; path = c/src/fiber.h; sourceTree = "<group>"; };
+		70D5A1972D155EDD00E75387 /* jump_gas.S */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm; path = jump_gas.S; sourceTree = "<group>"; };
+		70D5A1B22D155EDD00E75387 /* make_gas.S */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm; path = make_gas.S; sourceTree = "<group>"; };
+		70D5A1ED2D155EDD00E75387 /* boost_jmp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = boost_jmp.h; sourceTree = "<group>"; };
+		70D5A1EE2D155EDD00E75387 /* exp_jmp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = exp_jmp.h; sourceTree = "<group>"; };
+		70D5A1EF2D155EDD00E75387 /* fiber_unix.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fiber_unix.c; sourceTree = "<group>"; };
+		70D5A1F02D155EDD00E75387 /* fiber_win.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fiber_win.c; sourceTree = "<group>"; };
+		70D5A1F12D155EDD00E75387 /* x86_jmp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = x86_jmp.h; sourceTree = "<group>"; };
+		70D5A1F32D155EDD00E75387 /* fiber.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = fiber.c; path = c/src/fiber.c; sourceTree = "<group>"; };
+		70D5A1F42D155EDD00E75387 /* fiber_io.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = fiber_io.c; path = c/src/fiber_io.c; sourceTree = "<group>"; };
+		70D5A1F52D155EDD00E75387 /* file_event.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = file_event.c; path = c/src/file_event.c; sourceTree = "<group>"; };
+		70D5A1F62D155EDD00E75387 /* epoll.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = epoll.c; sourceTree = "<group>"; };
+		70D5A1F72D155EDD00E75387 /* fcntl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fcntl.c; sourceTree = "<group>"; };
+		70D5A1F82D155EDD00E75387 /* fiber_read.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fiber_read.c; sourceTree = "<group>"; };
+		70D5A1F92D155EDD00E75387 /* fiber_write.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fiber_write.c; sourceTree = "<group>"; };
+		70D5A1FA2D155EDD00E75387 /* file.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = file.c; sourceTree = "<group>"; };
+		70D5A1FB2D155EDD00E75387 /* getaddrinfo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = getaddrinfo.c; sourceTree = "<group>"; };
+		70D5A1FC2D155EDD00E75387 /* gethostbyname.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gethostbyname.c; sourceTree = "<group>"; };
+		70D5A1FD2D155EDD00E75387 /* hook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = hook.h; sourceTree = "<group>"; };
+		70D5A1FE2D155EDD00E75387 /* hook.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = hook.c; sourceTree = "<group>"; };
+		70D5A1FF2D155EDD00E75387 /* io.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = io.h; sourceTree = "<group>"; };
+		70D5A2002D155EDD00E75387 /* io.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = io.c; sourceTree = "<group>"; };
+		70D5A2012D155EDD00E75387 /* poll.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = poll.c; sourceTree = "<group>"; };
+		70D5A2022D155EDD00E75387 /* select.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = select.c; sourceTree = "<group>"; };
+		70D5A2032D155EDD00E75387 /* socket.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = socket.c; sourceTree = "<group>"; };
+		70D5A2052D155EDD00E75387 /* stdafx.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stdafx.h; path = c/src/stdafx.h; sourceTree = "<group>"; };
+		70D5A2062D155EDD00E75387 /* stdafx.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = stdafx.c; path = c/src/stdafx.c; sourceTree = "<group>"; };
+		70D5A2072D155EDD00E75387 /* channel.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = channel.c; sourceTree = "<group>"; };
+		70D5A2082D155EDD00E75387 /* fiber_cond.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fiber_cond.c; sourceTree = "<group>"; };
+		70D5A2092D155EDD00E75387 /* fiber_event.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fiber_event.c; sourceTree = "<group>"; };
+		70D5A20A2D155EDD00E75387 /* fiber_lock.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fiber_lock.c; sourceTree = "<group>"; };
+		70D5A20B2D155EDD00E75387 /* fiber_mutex.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fiber_mutex.c; sourceTree = "<group>"; };
+		70D5A20C2D155EDD00E75387 /* fiber_sem.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fiber_sem.c; sourceTree = "<group>"; };
+		70D5A20D2D155EDD00E75387 /* sync_timer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_timer.h; sourceTree = "<group>"; };
+		70D5A20E2D155EDD00E75387 /* sync_timer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sync_timer.c; sourceTree = "<group>"; };
+		70D5A20F2D155EDD00E75387 /* sync_type.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_type.h; sourceTree = "<group>"; };
+		70D5A2102D155EDD00E75387 /* sync_type.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sync_type.c; sourceTree = "<group>"; };
+		70D5A2112D155EDD00E75387 /* sync_waiter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_waiter.h; sourceTree = "<group>"; };
+		70D5A2122D155EDD00E75387 /* sync_waiter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sync_waiter.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -244,138 +300,25 @@
 		070F3528209021CB00672EDC /* src */ = {
 			isa = PBXGroup;
 			children = (
-				707539A3251E0567005B6E56 /* channel.c */,
-				7075399E251E0567005B6E56 /* common.h */,
-				707539AD251E0568005B6E56 /* define.h */,
-				707539A7251E0568005B6E56 /* event.c */,
-				707539A8251E0568005B6E56 /* event.h */,
-				707539AC251E0568005B6E56 /* fbase_event.c */,
-				707539A5251E0568005B6E56 /* fiber_cond.c */,
-				707539AB251E0568005B6E56 /* fiber_event.c */,
-				707539A1251E0567005B6E56 /* fiber_io.c */,
-				707539A4251E0567005B6E56 /* fiber_lock.c */,
-				707539A0251E0567005B6E56 /* fiber_sem.c */,
-				707539A9251E0568005B6E56 /* fiber.c */,
-				707539A2251E0567005B6E56 /* fiber.h */,
-				7075399F251E0567005B6E56 /* file_event.c */,
-				707539AA251E0568005B6E56 /* stdafx.c */,
-				707539A6251E0568005B6E56 /* stdafx.h */,
-				070F353C2090225C00672EDC /* common */,
-				070F35612090225C00672EDC /* dns */,
-				070F35682090225C00672EDC /* event */,
-				070F35772090225C00672EDC /* fiber */,
-				070F35812090225C00672EDC /* hook */,
+				70D5A1422D155EDD00E75387 /* common.h */,
+				70D5A1732D155EDD00E75387 /* common */,
+				70D5A1742D155EDD00E75387 /* define.h */,
+				70D5A17D2D155EDD00E75387 /* dns */,
+				70D5A17E2D155EDD00E75387 /* event.h */,
+				70D5A18D2D155EDD00E75387 /* event */,
+				70D5A18E2D155EDD00E75387 /* event.c */,
+				70D5A18F2D155EDD00E75387 /* fbase_event.c */,
+				70D5A1902D155EDD00E75387 /* fiber.h */,
+				70D5A1F22D155EDD00E75387 /* fiber */,
+				70D5A1F32D155EDD00E75387 /* fiber.c */,
+				70D5A1F42D155EDD00E75387 /* fiber_io.c */,
+				70D5A1F52D155EDD00E75387 /* file_event.c */,
+				70D5A2042D155EDD00E75387 /* hook */,
+				70D5A2052D155EDD00E75387 /* stdafx.h */,
+				70D5A2062D155EDD00E75387 /* stdafx.c */,
+				70D5A2132D155EDD00E75387 /* sync */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		070F353C2090225C00672EDC /* common */ = {
-			isa = PBXGroup;
-			children = (
-				7075390B251E049E005B6E56 /* argv.c */,
-				70753927251E04A0005B6E56 /* argv.h */,
-				70753926251E04A0005B6E56 /* array.c */,
-				70753925251E04A0005B6E56 /* array.h */,
-				70753908251E049E005B6E56 /* atomic.c */,
-				70753910251E049F005B6E56 /* atomic.h */,
-				70753912251E049F005B6E56 /* close_on_exec.c */,
-				70753914251E049F005B6E56 /* doze.c */,
-				70753907251E049E005B6E56 /* fifo.c */,
-				70753915251E049F005B6E56 /* fifo.h */,
-				70753917251E049F005B6E56 /* gettimeofday.c */,
-				7075391B251E049F005B6E56 /* gettimeofday.h */,
-				7075391A251E049F005B6E56 /* htable.c */,
-				70753923251E049F005B6E56 /* htable.h */,
-				7075391D251E049F005B6E56 /* init.c */,
-				7075390D251E049F005B6E56 /* init.h */,
-				70753906251E049E005B6E56 /* iostuff.h */,
-				70753918251E049F005B6E56 /* iterator.h */,
-				70753921251E049F005B6E56 /* memory.c */,
-				7075391E251E049F005B6E56 /* memory.h */,
-				7075391C251E049F005B6E56 /* msg.c */,
-				70753909251E049E005B6E56 /* msg.h */,
-				70753913251E049F005B6E56 /* non_blocking.c */,
-				70753922251E049F005B6E56 /* open_limit.c */,
-				7075390E251E049F005B6E56 /* pthread_patch.c */,
-				7075391F251E049F005B6E56 /* pthread_patch.h */,
-				7075390C251E049E005B6E56 /* ring.c */,
-				70753911251E049F005B6E56 /* ring.h */,
-				70753920251E049F005B6E56 /* sane_socket.c */,
-				70753916251E049F005B6E56 /* sane_socket.h */,
-				7075390F251E049F005B6E56 /* socketpair.c */,
-				70753924251E04A0005B6E56 /* strops.c */,
-				7075390A251E049E005B6E56 /* strops.h */,
-				70753919251E049F005B6E56 /* tcp_nodelay.c */,
-			);
-			name = common;
-			path = ../lib_fiber/c/src/common;
-			sourceTree = "<group>";
-		};
-		070F35612090225C00672EDC /* dns */ = {
-			isa = PBXGroup;
-			children = (
-				703BA806254DB0E000C8F36E /* resolver.c */,
-				703BA807254DB0E000C8F36E /* resolver.h */,
-				703BA805254DB0E000C8F36E /* rfc1035.c */,
-				703BA808254DB0E000C8F36E /* rfc1035.h */,
-				70753994251E053F005B6E56 /* sane_inet.c */,
-				70753997251E053F005B6E56 /* sane_inet.h */,
-				70753996251E053F005B6E56 /* valid_hostname.c */,
-				70753992251E053E005B6E56 /* valid_hostname.h */,
-			);
-			name = dns;
-			path = ../lib_fiber/c/src/dns;
-			sourceTree = "<group>";
-		};
-		070F35682090225C00672EDC /* event */ = {
-			isa = PBXGroup;
-			children = (
-				70753980251E0532005B6E56 /* event_epoll.c */,
-				7075397E251E0532005B6E56 /* event_epoll.h */,
-				70753985251E0533005B6E56 /* event_iocp.c */,
-				7075397F251E0532005B6E56 /* event_iocp.h */,
-				70753981251E0532005B6E56 /* event_kqueue.c */,
-				70753982251E0532005B6E56 /* event_kqueue.h */,
-				7075397B251E0532005B6E56 /* event_poll.c */,
-				7075397C251E0532005B6E56 /* event_poll.h */,
-				7075397A251E0532005B6E56 /* event_select.c */,
-				70753984251E0533005B6E56 /* event_select.h */,
-				70753983251E0532005B6E56 /* event_wmsg.c */,
-				7075397D251E0532005B6E56 /* event_wmsg.h */,
-			);
-			name = event;
-			path = ../lib_fiber/c/src/event;
-			sourceTree = "<group>";
-		};
-		070F35772090225C00672EDC /* fiber */ = {
-			isa = PBXGroup;
-			children = (
-				70753973251E0522005B6E56 /* boost_jmp.h */,
-				70753970251E0522005B6E56 /* exp_jmp.h */,
-				70753971251E0522005B6E56 /* fiber_unix.c */,
-				70753974251E0522005B6E56 /* fiber_win.c */,
-				70753972251E0522005B6E56 /* unix_jmp.h */,
-				70753865251E03ED005B6E56 /* boost */,
-			);
-			name = fiber;
-			path = ../lib_fiber/c/src/fiber;
-			sourceTree = "<group>";
-		};
-		070F35812090225C00672EDC /* hook */ = {
-			isa = PBXGroup;
-			children = (
-				70E41F6026F32AF90068042B /* hook.c */,
-				70753960251E0515005B6E56 /* epoll.c */,
-				7075395F251E0515005B6E56 /* getaddrinfo.c */,
-				70753961251E0515005B6E56 /* gethostbyname.c */,
-				7075395E251E0514005B6E56 /* hook.h */,
-				70753963251E0515005B6E56 /* io.c */,
-				70753964251E0515005B6E56 /* poll.c */,
-				70753966251E0515005B6E56 /* select.c */,
-				70753965251E0515005B6E56 /* socket.c */,
-			);
-			name = hook;
-			path = ../lib_fiber/c/src/hook;
 			sourceTree = "<group>";
 		};
 		070F361820902FF300672EDC /* fiber */ = {
@@ -395,13 +338,163 @@
 			name = fiber;
 			sourceTree = "<group>";
 		};
-		70753865251E03ED005B6E56 /* boost */ = {
+		70D5A1732D155EDD00E75387 /* common */ = {
 			isa = PBXGroup;
 			children = (
-				707539BE251E05DA005B6E56 /* jump_gas.S */,
-				707539BF251E05DA005B6E56 /* make_gas.S */,
+				70D5A1432D155EDD00E75387 /* argv.h */,
+				70D5A1442D155EDD00E75387 /* argv.c */,
+				70D5A1452D155EDD00E75387 /* array.h */,
+				70D5A1462D155EDD00E75387 /* array.c */,
+				70D5A1472D155EDD00E75387 /* atomic.h */,
+				70D5A1482D155EDD00E75387 /* atomic.c */,
+				70D5A1492D155EDD00E75387 /* avl.h */,
+				70D5A14A2D155EDD00E75387 /* avl.c */,
+				70D5A14B2D155EDD00E75387 /* avl_impl.h */,
+				70D5A14C2D155EDD00E75387 /* close_on_exec.c */,
+				70D5A14D2D155EDD00E75387 /* doze.c */,
+				70D5A14E2D155EDD00E75387 /* fifo.h */,
+				70D5A14F2D155EDD00E75387 /* fifo.c */,
+				70D5A1502D155EDD00E75387 /* gettimeofday.h */,
+				70D5A1512D155EDD00E75387 /* gettimeofday.c */,
+				70D5A1522D155EDD00E75387 /* htable.h */,
+				70D5A1532D155EDD00E75387 /* htable.c */,
+				70D5A1542D155EDD00E75387 /* init.h */,
+				70D5A1552D155EDD00E75387 /* init.c */,
+				70D5A1562D155EDD00E75387 /* iostuff.h */,
+				70D5A1572D155EDD00E75387 /* iterator.h */,
+				70D5A1582D155EDD00E75387 /* mbox.h */,
+				70D5A1592D155EDD00E75387 /* mbox.c */,
+				70D5A15A2D155EDD00E75387 /* memory.h */,
+				70D5A15B2D155EDD00E75387 /* memory.c */,
+				70D5A15C2D155EDD00E75387 /* msg.h */,
+				70D5A15D2D155EDD00E75387 /* msg.c */,
+				70D5A15E2D155EDD00E75387 /* non_blocking.c */,
+				70D5A15F2D155EDD00E75387 /* open_limit.c */,
+				70D5A1602D155EDD00E75387 /* pthread_patch.h */,
+				70D5A1612D155EDD00E75387 /* pthread_patch.c */,
+				70D5A1622D155EDD00E75387 /* queue.h */,
+				70D5A1632D155EDD00E75387 /* queue.c */,
+				70D5A1642D155EDD00E75387 /* read_wait.c */,
+				70D5A1652D155EDD00E75387 /* ring.h */,
+				70D5A1662D155EDD00E75387 /* ring.c */,
+				70D5A1672D155EDD00E75387 /* sane_socket.h */,
+				70D5A1682D155EDD00E75387 /* sane_socket.c */,
+				70D5A1692D155EDD00E75387 /* socketpair.c */,
+				70D5A16A2D155EDD00E75387 /* strops.h */,
+				70D5A16B2D155EDD00E75387 /* strops.c */,
+				70D5A16C2D155EDD00E75387 /* tcp_nodelay.c */,
+				70D5A16D2D155EDD00E75387 /* timer_cache.h */,
+				70D5A16E2D155EDD00E75387 /* timer_cache.c */,
+				70D5A16F2D155EDD00E75387 /* ypipe.h */,
+				70D5A1702D155EDD00E75387 /* ypipe.c */,
+				70D5A1712D155EDD00E75387 /* yqueue.h */,
+				70D5A1722D155EDD00E75387 /* yqueue.c */,
 			);
-			name = boost;
+			name = common;
+			path = c/src/common;
+			sourceTree = "<group>";
+		};
+		70D5A17D2D155EDD00E75387 /* dns */ = {
+			isa = PBXGroup;
+			children = (
+				70D5A1752D155EDD00E75387 /* resolver.h */,
+				70D5A1762D155EDD00E75387 /* resolver.c */,
+				70D5A1772D155EDD00E75387 /* rfc1035.h */,
+				70D5A1782D155EDD00E75387 /* rfc1035.c */,
+				70D5A1792D155EDD00E75387 /* sane_inet.h */,
+				70D5A17A2D155EDD00E75387 /* sane_inet.c */,
+				70D5A17B2D155EDD00E75387 /* valid_hostname.h */,
+				70D5A17C2D155EDD00E75387 /* valid_hostname.c */,
+			);
+			name = dns;
+			path = c/src/dns;
+			sourceTree = "<group>";
+		};
+		70D5A18D2D155EDD00E75387 /* event */ = {
+			isa = PBXGroup;
+			children = (
+				70D5A17F2D155EDD00E75387 /* event_epoll.h */,
+				70D5A1802D155EDD00E75387 /* event_epoll.c */,
+				70D5A1812D155EDD00E75387 /* event_io_uring.h */,
+				70D5A1822D155EDD00E75387 /* event_io_uring.c */,
+				70D5A1832D155EDD00E75387 /* event_iocp.h */,
+				70D5A1842D155EDD00E75387 /* event_iocp.c */,
+				70D5A1852D155EDD00E75387 /* event_kqueue.h */,
+				70D5A1862D155EDD00E75387 /* event_kqueue.c */,
+				70D5A1872D155EDD00E75387 /* event_poll.h */,
+				70D5A1882D155EDD00E75387 /* event_poll.c */,
+				70D5A1892D155EDD00E75387 /* event_select.h */,
+				70D5A18A2D155EDD00E75387 /* event_select.c */,
+				70D5A18B2D155EDD00E75387 /* event_wmsg.h */,
+				70D5A18C2D155EDD00E75387 /* event_wmsg.c */,
+			);
+			name = event;
+			path = c/src/event;
+			sourceTree = "<group>";
+		};
+		70D5A1E12D155EDD00E75387 /* boost */ = {
+			isa = PBXGroup;
+			children = (
+				70D5A1972D155EDD00E75387 /* jump_gas.S */,
+				70D5A1B22D155EDD00E75387 /* make_gas.S */,
+			);
+			path = boost;
+			sourceTree = "<group>";
+		};
+		70D5A1F22D155EDD00E75387 /* fiber */ = {
+			isa = PBXGroup;
+			children = (
+				70D5A1E12D155EDD00E75387 /* boost */,
+				70D5A1ED2D155EDD00E75387 /* boost_jmp.h */,
+				70D5A1EE2D155EDD00E75387 /* exp_jmp.h */,
+				70D5A1EF2D155EDD00E75387 /* fiber_unix.c */,
+				70D5A1F02D155EDD00E75387 /* fiber_win.c */,
+				70D5A1F12D155EDD00E75387 /* x86_jmp.h */,
+			);
+			name = fiber;
+			path = c/src/fiber;
+			sourceTree = "<group>";
+		};
+		70D5A2042D155EDD00E75387 /* hook */ = {
+			isa = PBXGroup;
+			children = (
+				70D5A1F62D155EDD00E75387 /* epoll.c */,
+				70D5A1F72D155EDD00E75387 /* fcntl.c */,
+				70D5A1F82D155EDD00E75387 /* fiber_read.c */,
+				70D5A1F92D155EDD00E75387 /* fiber_write.c */,
+				70D5A1FA2D155EDD00E75387 /* file.c */,
+				70D5A1FB2D155EDD00E75387 /* getaddrinfo.c */,
+				70D5A1FC2D155EDD00E75387 /* gethostbyname.c */,
+				70D5A1FD2D155EDD00E75387 /* hook.h */,
+				70D5A1FE2D155EDD00E75387 /* hook.c */,
+				70D5A1FF2D155EDD00E75387 /* io.h */,
+				70D5A2002D155EDD00E75387 /* io.c */,
+				70D5A2012D155EDD00E75387 /* poll.c */,
+				70D5A2022D155EDD00E75387 /* select.c */,
+				70D5A2032D155EDD00E75387 /* socket.c */,
+			);
+			name = hook;
+			path = c/src/hook;
+			sourceTree = "<group>";
+		};
+		70D5A2132D155EDD00E75387 /* sync */ = {
+			isa = PBXGroup;
+			children = (
+				70D5A2072D155EDD00E75387 /* channel.c */,
+				70D5A2082D155EDD00E75387 /* fiber_cond.c */,
+				70D5A2092D155EDD00E75387 /* fiber_event.c */,
+				70D5A20A2D155EDD00E75387 /* fiber_lock.c */,
+				70D5A20B2D155EDD00E75387 /* fiber_mutex.c */,
+				70D5A20C2D155EDD00E75387 /* fiber_sem.c */,
+				70D5A20D2D155EDD00E75387 /* sync_timer.h */,
+				70D5A20E2D155EDD00E75387 /* sync_timer.c */,
+				70D5A20F2D155EDD00E75387 /* sync_type.h */,
+				70D5A2102D155EDD00E75387 /* sync_type.c */,
+				70D5A2112D155EDD00E75387 /* sync_waiter.h */,
+				70D5A2122D155EDD00E75387 /* sync_waiter.c */,
+			);
+			name = sync;
+			path = c/src/sync;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -411,50 +504,62 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				70753949251E04A0005B6E56 /* argv.h in Headers */,
-				70753938251E04A0005B6E56 /* sane_socket.h in Headers */,
-				7075392C251E04A0005B6E56 /* strops.h in Headers */,
-				707539B8251E0568005B6E56 /* event.h in Headers */,
-				703BA80B254DB0E000C8F36E /* resolver.h in Headers */,
-				70753947251E04A0005B6E56 /* array.h in Headers */,
 				70753959251E0505005B6E56 /* fiber_sem.h in Headers */,
-				70753977251E0522005B6E56 /* unix_jmp.h in Headers */,
-				70753990251E0533005B6E56 /* event_select.h in Headers */,
-				70753998251E053F005B6E56 /* valid_hostname.h in Headers */,
 				70753954251E0505005B6E56 /* fiber_base.h in Headers */,
-				7075392B251E04A0005B6E56 /* msg.h in Headers */,
-				7075398E251E0533005B6E56 /* event_kqueue.h in Headers */,
+				70D5A2B02D155EDD00E75387 /* memory.h in Headers */,
+				70D5A2B12D155EDD00E75387 /* ring.h in Headers */,
+				70D5A2B22D155EDD00E75387 /* mbox.h in Headers */,
+				70D5A2B32D155EDD00E75387 /* fifo.h in Headers */,
+				70D5A2B42D155EDD00E75387 /* argv.h in Headers */,
+				70D5A2B52D155EDD00E75387 /* valid_hostname.h in Headers */,
+				70D5A2B62D155EDD00E75387 /* init.h in Headers */,
+				70D5A2B72D155EDD00E75387 /* sync_timer.h in Headers */,
+				70D5A2B82D155EDD00E75387 /* fiber.h in Headers */,
+				70D5A2B92D155EDD00E75387 /* pthread_patch.h in Headers */,
+				70D5A2BA2D155EDD00E75387 /* x86_jmp.h in Headers */,
+				70D5A2BB2D155EDD00E75387 /* event_kqueue.h in Headers */,
+				70D5A2BC2D155EDD00E75387 /* ypipe.h in Headers */,
+				70D5A2BD2D155EDD00E75387 /* array.h in Headers */,
+				70D5A2BE2D155EDD00E75387 /* iostuff.h in Headers */,
+				70D5A2BF2D155EDD00E75387 /* common.h in Headers */,
+				70D5A2C02D155EDD00E75387 /* htable.h in Headers */,
+				70D5A2C12D155EDD00E75387 /* sane_inet.h in Headers */,
+				70D5A2C22D155EDD00E75387 /* msg.h in Headers */,
+				70D5A2C32D155EDD00E75387 /* sane_socket.h in Headers */,
+				70D5A2C42D155EDD00E75387 /* yqueue.h in Headers */,
+				70D5A2C52D155EDD00E75387 /* event_poll.h in Headers */,
+				70D5A2C62D155EDD00E75387 /* stdafx.h in Headers */,
+				70D5A2C72D155EDD00E75387 /* strops.h in Headers */,
+				70D5A2C82D155EDD00E75387 /* event.h in Headers */,
+				70D5A2C92D155EDD00E75387 /* boost_jmp.h in Headers */,
+				70D5A2CA2D155EDD00E75387 /* event_wmsg.h in Headers */,
+				70D5A2CB2D155EDD00E75387 /* atomic.h in Headers */,
+				70D5A2CC2D155EDD00E75387 /* define.h in Headers */,
+				70D5A2CD2D155EDD00E75387 /* timer_cache.h in Headers */,
+				70D5A2CE2D155EDD00E75387 /* hook.h in Headers */,
+				70D5A2CF2D155EDD00E75387 /* event_io_uring.h in Headers */,
+				70D5A2D02D155EDD00E75387 /* iterator.h in Headers */,
+				70D5A2D12D155EDD00E75387 /* exp_jmp.h in Headers */,
+				70D5A2D22D155EDD00E75387 /* event_epoll.h in Headers */,
+				70D5A2D32D155EDD00E75387 /* gettimeofday.h in Headers */,
+				70D5A2D42D155EDD00E75387 /* avl.h in Headers */,
+				70D5A2D52D155EDD00E75387 /* queue.h in Headers */,
+				70D5A2D62D155EDD00E75387 /* avl_impl.h in Headers */,
+				70D5A2D72D155EDD00E75387 /* sync_type.h in Headers */,
+				70D5A2D82D155EDD00E75387 /* io.h in Headers */,
+				70D5A2D92D155EDD00E75387 /* event_select.h in Headers */,
+				70D5A2DA2D155EDD00E75387 /* resolver.h in Headers */,
+				70D5A2DB2D155EDD00E75387 /* event_iocp.h in Headers */,
+				70D5A2DC2D155EDD00E75387 /* sync_waiter.h in Headers */,
+				70D5A2DD2D155EDD00E75387 /* rfc1035.h in Headers */,
 				7075395C251E0505005B6E56 /* fiber_channel.h in Headers */,
-				70753945251E04A0005B6E56 /* htable.h in Headers */,
-				703BA80C254DB0E000C8F36E /* rfc1035.h in Headers */,
 				70753957251E0505005B6E56 /* fiber_cond.h in Headers */,
-				7075398A251E0533005B6E56 /* event_epoll.h in Headers */,
-				7075392F251E04A0005B6E56 /* init.h in Headers */,
-				70753978251E0522005B6E56 /* boost_jmp.h in Headers */,
 				7075395B251E0505005B6E56 /* fiber_lock.h in Headers */,
-				70753941251E04A0005B6E56 /* pthread_patch.h in Headers */,
 				70753955251E0505005B6E56 /* libfiber.h in Headers */,
-				707539BD251E0568005B6E56 /* define.h in Headers */,
 				7075395D251E0505005B6E56 /* fiber_event.h in Headers */,
-				70753940251E04A0005B6E56 /* memory.h in Headers */,
-				70753937251E04A0005B6E56 /* fifo.h in Headers */,
-				70753989251E0533005B6E56 /* event_wmsg.h in Headers */,
-				7075398B251E0533005B6E56 /* event_iocp.h in Headers */,
-				70753967251E0515005B6E56 /* hook.h in Headers */,
 				70753958251E0505005B6E56 /* fiber_define.h in Headers */,
 				7075395A251E0505005B6E56 /* lib_fiber.h in Headers */,
-				70753975251E0522005B6E56 /* exp_jmp.h in Headers */,
-				707539B2251E0568005B6E56 /* fiber.h in Headers */,
 				70753956251E0505005B6E56 /* fiber_hook.h in Headers */,
-				7075399D251E053F005B6E56 /* sane_inet.h in Headers */,
-				707539B6251E0568005B6E56 /* stdafx.h in Headers */,
-				707539AE251E0568005B6E56 /* common.h in Headers */,
-				70753932251E04A0005B6E56 /* atomic.h in Headers */,
-				70753988251E0533005B6E56 /* event_poll.h in Headers */,
-				7075393A251E04A0005B6E56 /* iterator.h in Headers */,
-				70753933251E04A0005B6E56 /* ring.h in Headers */,
-				70753928251E04A0005B6E56 /* iostuff.h in Headers */,
-				7075393D251E04A0005B6E56 /* gettimeofday.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -515,58 +620,74 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				70E41F6126F32AF90068042B /* hook.c in Sources */,
-				70753931251E04A0005B6E56 /* socketpair.c in Sources */,
-				70753948251E04A0005B6E56 /* array.c in Sources */,
-				70753968251E0515005B6E56 /* getaddrinfo.c in Sources */,
-				7075392A251E04A0005B6E56 /* atomic.c in Sources */,
-				707539B9251E0568005B6E56 /* fiber.c in Sources */,
-				70753942251E04A0005B6E56 /* sane_socket.c in Sources */,
-				707539B4251E0568005B6E56 /* fiber_lock.c in Sources */,
-				70753987251E0533005B6E56 /* event_poll.c in Sources */,
-				7075399C251E053F005B6E56 /* valid_hostname.c in Sources */,
-				7075396A251E0515005B6E56 /* gethostbyname.c in Sources */,
-				707539B5251E0568005B6E56 /* fiber_cond.c in Sources */,
-				7075399A251E053F005B6E56 /* sane_inet.c in Sources */,
-				70753939251E04A0005B6E56 /* gettimeofday.c in Sources */,
-				70753929251E04A0005B6E56 /* fifo.c in Sources */,
-				7075393F251E04A0005B6E56 /* init.c in Sources */,
-				707539BC251E0568005B6E56 /* fbase_event.c in Sources */,
-				703BA809254DB0E000C8F36E /* rfc1035.c in Sources */,
-				703BA80A254DB0E000C8F36E /* resolver.c in Sources */,
-				707539BB251E0568005B6E56 /* fiber_event.c in Sources */,
-				70753969251E0515005B6E56 /* epoll.c in Sources */,
-				7075396D251E0515005B6E56 /* poll.c in Sources */,
-				70753943251E04A0005B6E56 /* memory.c in Sources */,
-				70753986251E0533005B6E56 /* event_select.c in Sources */,
-				70753934251E04A0005B6E56 /* close_on_exec.c in Sources */,
-				7075393E251E04A0005B6E56 /* msg.c in Sources */,
-				7075396E251E0515005B6E56 /* socket.c in Sources */,
-				70753935251E04A0005B6E56 /* non_blocking.c in Sources */,
-				70753930251E04A0005B6E56 /* pthread_patch.c in Sources */,
-				707539B3251E0568005B6E56 /* channel.c in Sources */,
-				70753936251E04A0005B6E56 /* doze.c in Sources */,
-				707539B0251E0568005B6E56 /* fiber_sem.c in Sources */,
-				70753944251E04A0005B6E56 /* open_limit.c in Sources */,
-				7075396F251E0515005B6E56 /* select.c in Sources */,
-				7075396C251E0515005B6E56 /* io.c in Sources */,
-				70753946251E04A0005B6E56 /* strops.c in Sources */,
-				7075393C251E04A0005B6E56 /* htable.c in Sources */,
-				7075398D251E0533005B6E56 /* event_kqueue.c in Sources */,
-				707539BA251E0568005B6E56 /* stdafx.c in Sources */,
-				7075393B251E04A0005B6E56 /* tcp_nodelay.c in Sources */,
-				70753991251E0533005B6E56 /* event_iocp.c in Sources */,
-				707539AF251E0568005B6E56 /* file_event.c in Sources */,
-				70753976251E0522005B6E56 /* fiber_unix.c in Sources */,
-				7075398C251E0533005B6E56 /* event_epoll.c in Sources */,
-				7075398F251E0533005B6E56 /* event_wmsg.c in Sources */,
-				7075392D251E04A0005B6E56 /* argv.c in Sources */,
-				707539B1251E0568005B6E56 /* fiber_io.c in Sources */,
-				707539B7251E0568005B6E56 /* event.c in Sources */,
-				70753979251E0522005B6E56 /* fiber_win.c in Sources */,
-				7075392E251E04A0005B6E56 /* ring.c in Sources */,
-				707539C0251E05DA005B6E56 /* jump_gas.S in Sources */,
-				707539C1251E05DA005B6E56 /* make_gas.S in Sources */,
+				70D5A2142D155EDD00E75387 /* event_epoll.c in Sources */,
+				70D5A2182D155EDD00E75387 /* argv.c in Sources */,
+				70D5A2192D155EDD00E75387 /* jump_gas.S in Sources */,
+				70D5A21B2D155EDD00E75387 /* pthread_patch.c in Sources */,
+				70D5A21C2D155EDD00E75387 /* yqueue.c in Sources */,
+				70D5A21D2D155EDD00E75387 /* gethostbyname.c in Sources */,
+				70D5A21F2D155EDD00E75387 /* event.c in Sources */,
+				70D5A2212D155EDD00E75387 /* strops.c in Sources */,
+				70D5A2222D155EDD00E75387 /* socket.c in Sources */,
+				70D5A2252D155EDD00E75387 /* sync_waiter.c in Sources */,
+				70D5A2262D155EDD00E75387 /* fiber_read.c in Sources */,
+				70D5A2272D155EDD00E75387 /* rfc1035.c in Sources */,
+				70D5A2292D155EDD00E75387 /* avl.c in Sources */,
+				70D5A22B2D155EDD00E75387 /* fcntl.c in Sources */,
+				70D5A22E2D155EDD00E75387 /* fiber_write.c in Sources */,
+				70D5A2332D155EDD00E75387 /* hook.c in Sources */,
+				70D5A2352D155EDD00E75387 /* sane_inet.c in Sources */,
+				70D5A2372D155EDD00E75387 /* sync_type.c in Sources */,
+				70D5A2382D155EDD00E75387 /* resolver.c in Sources */,
+				70D5A2392D155EDD00E75387 /* stdafx.c in Sources */,
+				70D5A23F2D155EDD00E75387 /* event_poll.c in Sources */,
+				70D5A2412D155EDD00E75387 /* atomic.c in Sources */,
+				70D5A2432D155EDD00E75387 /* event_kqueue.c in Sources */,
+				70D5A2462D155EDD00E75387 /* io.c in Sources */,
+				70D5A2482D155EDD00E75387 /* fiber.c in Sources */,
+				70D5A2492D155EDD00E75387 /* event_iocp.c in Sources */,
+				70D5A24B2D155EDD00E75387 /* doze.c in Sources */,
+				70D5A24F2D155EDD00E75387 /* poll.c in Sources */,
+				70D5A2552D155EDD00E75387 /* ypipe.c in Sources */,
+				70D5A2592D155EDD00E75387 /* fiber_sem.c in Sources */,
+				70D5A25D2D155EDD00E75387 /* ring.c in Sources */,
+				70D5A25E2D155EDD00E75387 /* socketpair.c in Sources */,
+				70D5A25F2D155EDD00E75387 /* getaddrinfo.c in Sources */,
+				70D5A2602D155EDD00E75387 /* fiber_io.c in Sources */,
+				70D5A2612D155EDD00E75387 /* fiber_event.c in Sources */,
+				70D5A2622D155EDD00E75387 /* file_event.c in Sources */,
+				70D5A2632D155EDD00E75387 /* select.c in Sources */,
+				70D5A2642D155EDD00E75387 /* event_io_uring.c in Sources */,
+				70D5A2672D155EDD00E75387 /* gettimeofday.c in Sources */,
+				70D5A2682D155EDD00E75387 /* htable.c in Sources */,
+				70D5A2692D155EDD00E75387 /* queue.c in Sources */,
+				70D5A26C2D155EDD00E75387 /* fifo.c in Sources */,
+				70D5A26E2D155EDD00E75387 /* init.c in Sources */,
+				70D5A2722D155EDD00E75387 /* mbox.c in Sources */,
+				70D5A2742D155EDD00E75387 /* fiber_lock.c in Sources */,
+				70D5A2752D155EDD00E75387 /* open_limit.c in Sources */,
+				70D5A2772D155EDD00E75387 /* channel.c in Sources */,
+				70D5A2782D155EDD00E75387 /* event_wmsg.c in Sources */,
+				70D5A2792D155EDD00E75387 /* close_on_exec.c in Sources */,
+				70D5A27B2D155EDD00E75387 /* tcp_nodelay.c in Sources */,
+				70D5A27D2D155EDD00E75387 /* fiber_mutex.c in Sources */,
+				70D5A27E2D155EDD00E75387 /* memory.c in Sources */,
+				70D5A2812D155EDD00E75387 /* read_wait.c in Sources */,
+				70D5A2822D155EDD00E75387 /* make_gas.S in Sources */,
+				70D5A2832D155EDD00E75387 /* non_blocking.c in Sources */,
+				70D5A2862D155EDD00E75387 /* timer_cache.c in Sources */,
+				70D5A2872D155EDD00E75387 /* epoll.c in Sources */,
+				70D5A28B2D155EDD00E75387 /* file.c in Sources */,
+				70D5A28F2D155EDD00E75387 /* event_select.c in Sources */,
+				70D5A2912D155EDD00E75387 /* fiber_unix.c in Sources */,
+				70D5A2952D155EDD00E75387 /* valid_hostname.c in Sources */,
+				70D5A29B2D155EDD00E75387 /* sync_timer.c in Sources */,
+				70D5A29C2D155EDD00E75387 /* array.c in Sources */,
+				70D5A29D2D155EDD00E75387 /* fiber_win.c in Sources */,
+				70D5A29E2D155EDD00E75387 /* msg.c in Sources */,
+				70D5A2A32D155EDD00E75387 /* fiber_cond.c in Sources */,
+				70D5A2A52D155EDD00E75387 /* fbase_event.c in Sources */,
+				70D5A2AE2D155EDD00E75387 /* sane_socket.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/fiber_cpp.xcodeproj/project.pbxproj
+++ b/fiber_cpp.xcodeproj/project.pbxproj
@@ -7,16 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		707539D2251E472E005B6E56 /* fiber_event.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539C8251E472E005B6E56 /* fiber_event.hpp */; };
-		707539D3251E472E005B6E56 /* fiber_lock.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539C9251E472E005B6E56 /* fiber_lock.hpp */; };
-		707539D4251E472E005B6E56 /* fiber_tbox.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539CA251E472E005B6E56 /* fiber_tbox.hpp */; };
-		707539D5251E472E005B6E56 /* go_fiber.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539CB251E472E005B6E56 /* go_fiber.hpp */; };
-		707539D6251E472E005B6E56 /* channel.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539CC251E472E005B6E56 /* channel.hpp */; };
-		707539D7251E472E005B6E56 /* libfiber.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539CD251E472E005B6E56 /* libfiber.hpp */; };
-		707539D8251E472E005B6E56 /* fiber_cpp_define.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539CE251E472E005B6E56 /* fiber_cpp_define.hpp */; };
-		707539D9251E472E005B6E56 /* fiber_cond.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539CF251E472E005B6E56 /* fiber_cond.hpp */; };
-		707539DA251E472E005B6E56 /* fiber.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539D0251E472E005B6E56 /* fiber.hpp */; };
-		707539DB251E472E005B6E56 /* fiber_sem.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539D1251E472E005B6E56 /* fiber_sem.hpp */; };
 		707539E4251E473E005B6E56 /* fiber_lock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 707539DC251E473E005B6E56 /* fiber_lock.cpp */; };
 		707539E5251E473E005B6E56 /* fiber_event.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 707539DD251E473E005B6E56 /* fiber_event.cpp */; };
 		707539E6251E473E005B6E56 /* fiber_sem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 707539DE251E473E005B6E56 /* fiber_sem.cpp */; };
@@ -25,22 +15,15 @@
 		707539E9251E473E005B6E56 /* stdafx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 707539E1251E473E005B6E56 /* stdafx.cpp */; };
 		707539EA251E473E005B6E56 /* stdafx.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 707539E2251E473E005B6E56 /* stdafx.hpp */; };
 		707539EB251E473E005B6E56 /* fiber_cond.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 707539E3251E473E005B6E56 /* fiber_cond.cpp */; };
+		70D5A2E12D15604C00E75387 /* fiber_mutex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2DE2D15604C00E75387 /* fiber_mutex.cpp */; };
+		70D5A2E22D15604C00E75387 /* wait_group.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2E02D15604C00E75387 /* wait_group.cpp */; };
+		70D5A2E32D15604C00E75387 /* fiber_mutex_stat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70D5A2DF2D15604C00E75387 /* fiber_mutex_stat.cpp */; };
 		70E41F5D26F32AA90068042B /* winapi_hook.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70E41F5B26F32AA90068042B /* winapi_hook.cpp */; };
 		70E41F5E26F32AA90068042B /* winapi_hook.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 70E41F5C26F32AA90068042B /* winapi_hook.hpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		070F35E320902D9800672EDC /* libfiber_cpp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libfiber_cpp.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		707539C8251E472E005B6E56 /* fiber_event.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fiber_event.hpp; path = cpp/include/fiber/fiber_event.hpp; sourceTree = SOURCE_ROOT; };
-		707539C9251E472E005B6E56 /* fiber_lock.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fiber_lock.hpp; path = cpp/include/fiber/fiber_lock.hpp; sourceTree = SOURCE_ROOT; };
-		707539CA251E472E005B6E56 /* fiber_tbox.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fiber_tbox.hpp; path = cpp/include/fiber/fiber_tbox.hpp; sourceTree = SOURCE_ROOT; };
-		707539CB251E472E005B6E56 /* go_fiber.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = go_fiber.hpp; path = cpp/include/fiber/go_fiber.hpp; sourceTree = SOURCE_ROOT; };
-		707539CC251E472E005B6E56 /* channel.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = channel.hpp; path = cpp/include/fiber/channel.hpp; sourceTree = SOURCE_ROOT; };
-		707539CD251E472E005B6E56 /* libfiber.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = libfiber.hpp; path = cpp/include/fiber/libfiber.hpp; sourceTree = SOURCE_ROOT; };
-		707539CE251E472E005B6E56 /* fiber_cpp_define.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fiber_cpp_define.hpp; path = cpp/include/fiber/fiber_cpp_define.hpp; sourceTree = SOURCE_ROOT; };
-		707539CF251E472E005B6E56 /* fiber_cond.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fiber_cond.hpp; path = cpp/include/fiber/fiber_cond.hpp; sourceTree = SOURCE_ROOT; };
-		707539D0251E472E005B6E56 /* fiber.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fiber.hpp; path = cpp/include/fiber/fiber.hpp; sourceTree = SOURCE_ROOT; };
-		707539D1251E472E005B6E56 /* fiber_sem.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fiber_sem.hpp; path = cpp/include/fiber/fiber_sem.hpp; sourceTree = SOURCE_ROOT; };
 		707539DC251E473E005B6E56 /* fiber_lock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fiber_lock.cpp; path = cpp/src/fiber_lock.cpp; sourceTree = "<group>"; };
 		707539DD251E473E005B6E56 /* fiber_event.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fiber_event.cpp; path = cpp/src/fiber_event.cpp; sourceTree = "<group>"; };
 		707539DE251E473E005B6E56 /* fiber_sem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fiber_sem.cpp; path = cpp/src/fiber_sem.cpp; sourceTree = "<group>"; };
@@ -49,6 +32,23 @@
 		707539E1251E473E005B6E56 /* stdafx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = stdafx.cpp; path = cpp/src/stdafx.cpp; sourceTree = "<group>"; };
 		707539E2251E473E005B6E56 /* stdafx.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = stdafx.hpp; path = cpp/src/stdafx.hpp; sourceTree = "<group>"; };
 		707539E3251E473E005B6E56 /* fiber_cond.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fiber_cond.cpp; path = cpp/src/fiber_cond.cpp; sourceTree = "<group>"; };
+		70D5A2DE2D15604C00E75387 /* fiber_mutex.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fiber_mutex.cpp; path = cpp/src/fiber_mutex.cpp; sourceTree = "<group>"; };
+		70D5A2DF2D15604C00E75387 /* fiber_mutex_stat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fiber_mutex_stat.cpp; path = cpp/src/fiber_mutex_stat.cpp; sourceTree = "<group>"; };
+		70D5A2E02D15604C00E75387 /* wait_group.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = wait_group.cpp; path = cpp/src/wait_group.cpp; sourceTree = "<group>"; };
+		70D5A3012D15609E00E75387 /* channel.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = channel.hpp; sourceTree = "<group>"; };
+		70D5A3022D15609E00E75387 /* fiber.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber.hpp; sourceTree = "<group>"; };
+		70D5A3032D15609E00E75387 /* fiber_cond.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber_cond.hpp; sourceTree = "<group>"; };
+		70D5A3042D15609E00E75387 /* fiber_cpp_define.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber_cpp_define.hpp; sourceTree = "<group>"; };
+		70D5A3052D15609E00E75387 /* fiber_event.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber_event.hpp; sourceTree = "<group>"; };
+		70D5A3062D15609E00E75387 /* fiber_lock.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber_lock.hpp; sourceTree = "<group>"; };
+		70D5A3072D15609E00E75387 /* fiber_mutex.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber_mutex.hpp; sourceTree = "<group>"; };
+		70D5A3082D15609E00E75387 /* fiber_mutex_stat.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber_mutex_stat.hpp; sourceTree = "<group>"; };
+		70D5A3092D15609E00E75387 /* fiber_sem.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber_sem.hpp; sourceTree = "<group>"; };
+		70D5A30A2D15609E00E75387 /* fiber_tbox.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber_tbox.hpp; sourceTree = "<group>"; };
+		70D5A30B2D15609E00E75387 /* fiber_tbox2.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fiber_tbox2.hpp; sourceTree = "<group>"; };
+		70D5A30C2D15609E00E75387 /* go_fiber.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = go_fiber.hpp; sourceTree = "<group>"; };
+		70D5A30D2D15609E00E75387 /* libfiber.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = libfiber.hpp; sourceTree = "<group>"; };
+		70D5A30E2D15609E00E75387 /* wait_group.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = wait_group.hpp; sourceTree = "<group>"; };
 		70E41F5B26F32AA90068042B /* winapi_hook.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = winapi_hook.cpp; path = cpp/src/winapi_hook.cpp; sourceTree = "<group>"; };
 		70E41F5C26F32AA90068042B /* winapi_hook.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = winapi_hook.hpp; path = cpp/src/winapi_hook.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -67,6 +67,7 @@
 		070F35DA20902D9800672EDC = {
 			isa = PBXGroup;
 			children = (
+				70D5A3102D15609E00E75387 /* include */,
 				070F35F220902DB100672EDC /* src */,
 				070F35F120902DA700672EDC /* include */,
 				070F35E420902D9800672EDC /* Products */,
@@ -84,7 +85,6 @@
 		070F35F120902DA700672EDC /* include */ = {
 			isa = PBXGroup;
 			children = (
-				070F35F320902DDC00672EDC /* fiber */,
 			);
 			name = include;
 			sourceTree = "<group>";
@@ -92,6 +92,9 @@
 		070F35F220902DB100672EDC /* src */ = {
 			isa = PBXGroup;
 			children = (
+				70D5A2DE2D15604C00E75387 /* fiber_mutex.cpp */,
+				70D5A2DF2D15604C00E75387 /* fiber_mutex_stat.cpp */,
+				70D5A2E02D15604C00E75387 /* wait_group.cpp */,
 				70E41F5B26F32AA90068042B /* winapi_hook.cpp */,
 				70E41F5C26F32AA90068042B /* winapi_hook.hpp */,
 				707539E0251E473E005B6E56 /* channel.cpp */,
@@ -106,22 +109,34 @@
 			name = src;
 			sourceTree = "<group>";
 		};
-		070F35F320902DDC00672EDC /* fiber */ = {
+		70D5A30F2D15609E00E75387 /* fiber */ = {
 			isa = PBXGroup;
 			children = (
-				707539CC251E472E005B6E56 /* channel.hpp */,
-				707539CF251E472E005B6E56 /* fiber_cond.hpp */,
-				707539CE251E472E005B6E56 /* fiber_cpp_define.hpp */,
-				707539C8251E472E005B6E56 /* fiber_event.hpp */,
-				707539C9251E472E005B6E56 /* fiber_lock.hpp */,
-				707539D1251E472E005B6E56 /* fiber_sem.hpp */,
-				707539CA251E472E005B6E56 /* fiber_tbox.hpp */,
-				707539D0251E472E005B6E56 /* fiber.hpp */,
-				707539CB251E472E005B6E56 /* go_fiber.hpp */,
-				707539CD251E472E005B6E56 /* libfiber.hpp */,
+				70D5A3012D15609E00E75387 /* channel.hpp */,
+				70D5A3022D15609E00E75387 /* fiber.hpp */,
+				70D5A3032D15609E00E75387 /* fiber_cond.hpp */,
+				70D5A3042D15609E00E75387 /* fiber_cpp_define.hpp */,
+				70D5A3052D15609E00E75387 /* fiber_event.hpp */,
+				70D5A3062D15609E00E75387 /* fiber_lock.hpp */,
+				70D5A3072D15609E00E75387 /* fiber_mutex.hpp */,
+				70D5A3082D15609E00E75387 /* fiber_mutex_stat.hpp */,
+				70D5A3092D15609E00E75387 /* fiber_sem.hpp */,
+				70D5A30A2D15609E00E75387 /* fiber_tbox.hpp */,
+				70D5A30B2D15609E00E75387 /* fiber_tbox2.hpp */,
+				70D5A30C2D15609E00E75387 /* go_fiber.hpp */,
+				70D5A30D2D15609E00E75387 /* libfiber.hpp */,
+				70D5A30E2D15609E00E75387 /* wait_group.hpp */,
 			);
-			name = fiber;
-			path = ../lib_fiber/cpp/include/fiber;
+			path = fiber;
+			sourceTree = "<group>";
+		};
+		70D5A3102D15609E00E75387 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				70D5A30F2D15609E00E75387 /* fiber */,
+			);
+			name = include;
+			path = cpp/include;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -131,18 +146,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				707539D4251E472E005B6E56 /* fiber_tbox.hpp in Headers */,
-				707539D2251E472E005B6E56 /* fiber_event.hpp in Headers */,
-				707539D8251E472E005B6E56 /* fiber_cpp_define.hpp in Headers */,
-				707539D9251E472E005B6E56 /* fiber_cond.hpp in Headers */,
 				707539EA251E473E005B6E56 /* stdafx.hpp in Headers */,
-				707539DA251E472E005B6E56 /* fiber.hpp in Headers */,
-				707539D3251E472E005B6E56 /* fiber_lock.hpp in Headers */,
-				707539D6251E472E005B6E56 /* channel.hpp in Headers */,
-				707539D7251E472E005B6E56 /* libfiber.hpp in Headers */,
 				70E41F5E26F32AA90068042B /* winapi_hook.hpp in Headers */,
-				707539D5251E472E005B6E56 /* go_fiber.hpp in Headers */,
-				707539DB251E472E005B6E56 /* fiber_sem.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -211,6 +216,9 @@
 				707539E5251E473E005B6E56 /* fiber_event.cpp in Sources */,
 				707539E4251E473E005B6E56 /* fiber_lock.cpp in Sources */,
 				707539E9251E473E005B6E56 /* stdafx.cpp in Sources */,
+				70D5A2E12D15604C00E75387 /* fiber_mutex.cpp in Sources */,
+				70D5A2E22D15604C00E75387 /* wait_group.cpp in Sources */,
+				70D5A2E32D15604C00E75387 /* fiber_mutex_stat.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/samples/cxx/waite_group/Makefile
+++ b/samples/cxx/waite_group/Makefile
@@ -1,0 +1,3 @@
+include ../Makefile.in
+PROG = waite_group
+CFLAGS += -std=c++11

--- a/samples/cxx/waite_group/main.cpp
+++ b/samples/cxx/waite_group/main.cpp
@@ -1,0 +1,93 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <thread>
+#include <iostream>
+#include "fiber/wait_group.hpp"
+#include "fiber/go_fiber.hpp"
+
+static int __delay = 1;
+
+static void usage(const char* procname) {
+	printf("usage: %s -h [help]\r\n"
+		" -e event_type[kernel|poll|select|io_uring]\r\n"
+		" -t threads_count[default: 1]\r\n"
+		" -c fibers_count[default: 1]\r\n"
+		" -d delay[default: 1 second]\r\n"
+		, procname);
+}
+
+int main(int argc, char *argv[]) {
+	int  ch, threads_count = 1, fibers_count = 1;
+	acl::fiber_event_t event_type = acl::FIBER_EVENT_T_KERNEL;
+
+	while ((ch = getopt(argc, argv, "he:t:f:c:d:")) > 0) {
+		switch (ch) {
+		case 'h':
+			usage(argv[0]);
+			return 0;
+		case 'e':
+			if (strcasecmp(optarg, "kernel") == 0) {
+				event_type = acl::FIBER_EVENT_T_KERNEL;
+			} else if (strcasecmp(optarg, "select") == 0) {
+				event_type = acl::FIBER_EVENT_T_SELECT;
+			} else if (strcasecmp(optarg, "poll") == 0) {
+				event_type = acl::FIBER_EVENT_T_POLL;
+			} else if (strcasecmp(optarg, "io_uring") == 0) {
+				event_type = acl::FIBER_EVENT_T_IO_URING;
+			}
+			break;
+		case 't':
+			threads_count = atoi(optarg);
+			break;
+		case 'c':
+			fibers_count = atoi(optarg);
+			break;
+		case 'd':
+			__delay = atoi(optarg);
+			break;
+		default:
+			break;
+		}
+	}
+
+	acl::fiber::stdout_open(true);
+
+	acl::wait_group sync;
+	sync.add(threads_count + fibers_count);
+
+	for (int i = 0; i < threads_count; i++) {
+		std::thread* thr = new std::thread([&sync] {
+			std::cout << "Thread " << std::this_thread::get_id()
+				<< " started, delay " << __delay << " seconds\r\n";
+
+			::sleep((unsigned) __delay);
+
+			std::cout << "Thread "<< std::this_thread::get_id() << " done!\r\n";
+			sync.done();
+		});
+
+		thr->detach();
+	}
+
+	for (int i = 0; i < fibers_count; i++) {
+		go[&sync] {
+			std::cout << "Fiber-" << acl::fiber::self()
+				<< " started, delay " << __delay << " seconds\r\n",
+
+			::sleep((unsigned) __delay);
+
+			std::cout << "Fiber-" << acl::fiber::self() << " done!\r\n";
+			sync.done();
+		};
+	}
+
+	go[&sync] {
+		sync.wait();
+		printf("All threads and fibers were done\r\n");
+	};
+
+	acl::fiber::schedule_with(event_type);
+	return 0;
+}

--- a/samples/gui/EchoServer/EchoServer.vcxproj
+++ b/samples/gui/EchoServer/EchoServer.vcxproj
@@ -153,6 +153,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -180,6 +181,7 @@
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>
       </DisableSpecificWarnings>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -207,6 +209,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -236,6 +239,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;FIBER_CPP_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -265,6 +269,7 @@
       <PreprocessorDefinitions>_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -294,6 +299,7 @@
       <PreprocessorDefinitions>_WINDOWS;NDEBUG;FIBER_CPP_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -320,6 +326,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;FIBER_CPP_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -335,6 +342,7 @@
       <PreprocessorDefinitions>_WINDOWS;_DEBUG;FIBER_CPP_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>
       <OmitFramePointers>false</OmitFramePointers>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>libfiber.lib;libfiber_cpp.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/samples/gui/SimpleWin/SimpleWin.vcxproj
+++ b/samples/gui/SimpleWin/SimpleWin.vcxproj
@@ -157,6 +157,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -174,6 +175,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -193,6 +195,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -214,6 +217,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -233,6 +237,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -250,6 +255,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -269,6 +275,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -290,6 +297,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\..\cpp\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
- Use setsockopt to set the IO timeout handling process;
- Add fiber_tbox2 to transfer value object;
- Add wait_group like go sync.WaitGroup;
- More codes optimizing.